### PR TITLE
:lipstick: Only Disable Auto Activation If AutoSave Is Actually Enabled

### DIFF
--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -20,6 +20,7 @@ module.exports =
     # If both autosave and autocomplete+'s auto-activation feature are enabled,
     # disable the auto-activation
     if atom.packages.isPackageLoaded("autosave") and
+      atom.config.get("autosave.enabled") and
       atom.config.get("autocomplete-plus.enableAutoActivation")
         atom.config.set "autocomplete-plus.enableAutoActivation", false
 


### PR DESCRIPTION
Addresses warning issue raised in #16. Checking for whether autosave is loaded or not is overly restrictive. The conflict only occurs when autosave is actually enabled.
