### PR TITLE
Ensure 15-spec Runs Reliably By Using Temp Directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "atom": "*"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
     "fuzzaldrin": "~1.0.0",
-    "minimatch": "~0.2.14"
+    "minimatch": "~0.2.14",
+    "temp": ">=0.7.0",
+    "underscore-plus": "1.x"
   }
 }

--- a/spec/issues/15-spec.coffee
+++ b/spec/issues/15-spec.coffee
@@ -2,12 +2,15 @@ require "../spec-helper"
 {$, EditorView, WorkspaceView} = require 'atom'
 AutocompleteView = require '../../lib/autocomplete-view'
 Autocomplete = require '../../lib/autocomplete'
+path = require 'path'
+temp = require('temp').track()
 
 describe "Autocomplete", ->
-  [activationPromise, autocomplete, editorView, editor, completionDelay] = []
+  [activationPromise, autocomplete, directory, editorView, editor, completionDelay] = []
 
   describe "Issue 15", ->
     beforeEach ->
+      directory = temp.mkdirSync()
       # Create a fake workspace and open a sample file
       atom.workspaceView = new WorkspaceView
       atom.workspaceView.openSync "issues/11.js"
@@ -45,6 +48,6 @@ describe "Autocomplete", ->
 
         expect(editorView.find(".autocomplete-plus")).toExist()
 
-        editor.saveAs("spec/tmp/issue-11.js")
+        editor.saveAs(path.join(directory, "spec", "tmp", "issue-11.js"))
 
         expect(editorView.find(".autocomplete-plus")).not.toExist()


### PR DESCRIPTION
Without this change, the files get created at /spec/..., requiring privilege escalation and always failing unless you manually create the directory.

With this change, the test runs reliably using a temp directory.
