### PR TITLE
Map "enter" to selection confirmation

### DIFF
--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -1,4 +1,5 @@
 ".autocomplete-plus input.hidden-input":
+  "enter": "autocomplete-plus:confirm"
   "tab": "autocomplete-plus:confirm"
 
 ".editor":


### PR DESCRIPTION
Add "enter" (in addition to "tab") as default input for confirmation of selected completion.
Fix issue #39

(My first foray into pull requests, hence the trivial commit!)
