### PR TITLE
Fix a bug occurred after closing one of the copied tabs

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -256,3 +256,5 @@ class AutocompleteView extends SimpleSelectListView
     @currentBuffer?.off "saved", @onSaved
     @editor.off "title-changed-subscription-removed", @cancel
     @editor.off "cursor-moved", @cursorMoved
+    for provider in @providers when provider.dispose?
+      provider.dispose()

--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -153,3 +153,8 @@ class FuzzyProvider extends Provider
     completions = atom.syntax.propertiesForScope cursorScope, "editor.completions"
     completions = completions.map (properties) -> _.valueForKeyPath properties, "editor.completions"
     return Utils.unique _.flatten(completions)
+
+  # Public: Clean up, stop listening to events
+  dispose: ->
+    @currentBuffer?.off "changed", @onChanged
+    @currentBuffer?.off "saved", @onSaved

--- a/spec/fixtures/issues/50.js
+++ b/spec/fixtures/issues/50.js
@@ -1,0 +1,5 @@
+function Redraw() { }
+
+Redraw.prototype.redraw = function() {
+  console.log("foo");
+}


### PR DESCRIPTION
Atom seems to be a stranger after closing a tab which is opened in multiple panes.

In the following GIF, each time I pressed enter key, the next line seems to be lost and a error log appeared in the console. Once I reopen the tab, it works correctly.

![autocomplete-plus-bug](https://cloud.githubusercontent.com/assets/551939/2797657/8d050e12-cc37-11e3-919a-bd28475d48eb.gif)
