### PR TITLE
Support styles in html label

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -55,7 +55,7 @@ class AutocompleteView extends SimpleSelectListView
   # Private: Creates a view for the given item
   #
   # Returns a {jQuery} object that represents the item view
-  viewForItem: ({word, label, renderLabelAsHtml}) ->
+  viewForItem: ({word, label, renderLabelAsHtml, className}) ->
     item = $$ ->
       @li =>
         @span word, class: "word"
@@ -64,8 +64,9 @@ class AutocompleteView extends SimpleSelectListView
 
     if renderLabelAsHtml
       item.find(".label").html label
-      if renderLabelAsHtml.style?
-        item.find(".label").css renderLabelAsHtml.style
+
+    if className?
+      item.addClass className
 
     return item
 

--- a/lib/suggestion.coffee
+++ b/lib/suggestion.coffee
@@ -6,3 +6,4 @@ class Suggestion
     @label = options.label if options.label?
     @data = options.data if options.data?
     @renderLabelAsHtml = options.renderLabelAsHtml if options.renderLabelAsHtml?
+    @className = options.className if options.className?

--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -446,4 +446,4 @@ describe "Autocomplete", ->
           advanceClock completionDelay
 
           expect(autocompleteView.list.find("li:eq(0) .label")).toHaveHtml "<span style=\"color: red\">ohai</span>"
-          expect(parseFloat autocompleteView.list.find("li:eq(0) .label").css("opacity")).toBe 0.5
+          expect(autocompleteView.list.find("li:eq(0)")).toHaveClass "ohai"

--- a/spec/lib/test-provider.coffee
+++ b/spec/lib/test-provider.coffee
@@ -7,5 +7,6 @@ class TestProvider extends Provider
       word: "ohai",
       prefix: "ohai",
       label: "<span style=\"color: red\">ohai</span>",
-      renderLabelAsHtml: {style: {opacity: 0.5}}
+      renderLabelAsHtml: true,
+      className: 'ohai'
     )]


### PR DESCRIPTION
I would like to add this commit for customizing styles in html label as plugin wants.

This aims for brightly showing icons in my package ([autocomplete-emojis](https://github.com/eqot/autocomplete-emojis)) with a customized style which is `opacity: 1` instead of `opacity: 0.3` by default in autocomplete-plus.

If this does not fit your API style, you can modify this as you like.
