### PR TITLE
Add ctrl-n,p emacs bindings for next, previous

### DIFF
--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -1,7 +1,9 @@
 ".autocomplete-plus input.hidden-input":
   "tab": "autocomplete-plus:confirm"
   "down": "autocomplete-plus:select-next"
+  "ctrl-n": "autocomplete-plus:select-next"
   "up": "autocomplete-plus:select-previous"
+  "ctrl-p": "autocomplete-plus:select-previous"
   "escape": "autocomplete-plus:cancel"
 
 ".editor":


### PR DESCRIPTION
Emacs binds are supported through most of the rest of Atom. Plus it's rough having to drop down to the arrow keys in the midst of typing :)
