### PR TITLE
Filter by word length

### DIFF
--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -117,6 +117,12 @@ class FuzzyProvider extends Provider
     # Flatten the matches, make it an unique array
     wordList = _.flatten matches
     wordList = Utils.unique wordList
+
+    # Filter words by length
+    minimumWordLength = atom.config.get("autocomplete-plus.minimumWordLength")
+    if minimumWordLength
+      wordList = wordList.filter (word) -> word?.length >= minimumWordLength
+
     @wordList = wordList
 
     p.stop()


### PR DESCRIPTION
When 'includeCompletionsFromAllBuffers' is true, candidates include many short words like `on`, `tmp` so on.
I added filter by word length.

Example

``` coffee
'autocomplete-plus':
  'includeCompletionsFromAllBuffers': true
  'minimumWordLength': 4
```
