### PR TITLE
Flow out to contraints

### DIFF
--- a/stylesheets/autocomplete.less
+++ b/stylesheets/autocomplete.less
@@ -20,7 +20,6 @@
   ol.list-group {
     overflow-y: auto !important;
     margin-top: 0;
-    display: inline-block;
     li {
       .clearfix();
       .word {


### PR DESCRIPTION
In at least Atom `0.123.0` the menu looks jank. Fixed it by removing the `inline-block`.

**Before:**

![raml-object-builder_js_-__users_blakeembrey_projects_raml-object-builder 2](https://cloud.githubusercontent.com/assets/1088987/4032487/ab736ed6-2c70-11e4-8add-0a087d659b4f.png)

**After:**

![raml-object-builder_js_-__users_blakeembrey_projects_raml-object-builder](https://cloud.githubusercontent.com/assets/1088987/4032488/addd2504-2c70-11e4-815b-95f22aa5c029.png)
