### PR TITLE
one-line fix the situation when trying to use "Enter" key to confirm the...

### DIFF
--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -1,5 +1,6 @@
 ".autocomplete-plus input.hidden-input":
   "tab": "autocomplete-plus:confirm"
+  "enter": "autocomplete-plus:confirm"
   "down": "autocomplete-plus:select-next"
   "ctrl-n": "autocomplete-plus:select-next"
   "up": "autocomplete-plus:select-previous"


### PR DESCRIPTION
... autocomplete fails.

fix that issue:
https://github.com/saschagehlich/autocomplete-plus/issues/121
