### PR TITLE
Specifying richer tokens with the symbol provider

### DIFF
--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -108,9 +108,20 @@ class Symbol
 module.exports =
 class SymbolStore
   count: 0
+  wordRegexes: null
 
   constructor: (@wordRegex) ->
+    @wordRegexes = {}
     @clear()
+
+  setWordRegexForScopeDescriptor: (scopeDescriptor, wordRegex) ->
+    scopes = scopeDescriptor.getScopesArray?() ? scopeDescriptor
+    @wordRegexes[scopes[0]] = wordRegex if scopes?[0]?
+
+  wordRegexForScopeDescriptor: (scopeDescriptor) ->
+    scopes = scopeDescriptor.getScopesArray?() ? scopeDescriptor
+    wordRegex = @wordRegexes[scopes?[0]]
+    wordRegex ? @wordRegex
 
   clear: (bufferPath) ->
     if bufferPath?
@@ -151,7 +162,8 @@ class SymbolStore
     # This could be made async...
     text = @getTokenText(token)
     scopeChain = @getTokenScopeChain(token)
-    matches = text.match(@wordRegex)
+    wordRegex = @wordRegexForScopeDescriptor(token.scopes)
+    matches = text.match(wordRegex)
     if matches?
       @addSymbol(symbolText, bufferPath, bufferRow, scopeChain) for symbolText in matches
     return
@@ -160,7 +172,8 @@ class SymbolStore
     # This could be made async...
     text = @getTokenText(token)
     scopeChain = @getTokenScopeChain(token)
-    matches = text.match(@wordRegex)
+    wordRegex = @wordRegexForScopeDescriptor(token.scopes)
+    matches = text.match(wordRegex)
     if matches?
       @removeSymbol(symbolText, bufferPath, bufferRow, scopeChain) for symbolText in matches
     return

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -124,6 +124,7 @@ class SymbolStore
     wordRegex ? @wordRegex
 
   clear: (bufferPath) ->
+    console.log 'rem all', bufferPath
     if bufferPath?
       for symbolKey, symbol of @symbolMap
         symbol.clearForBufferPath(bufferPath)
@@ -164,6 +165,7 @@ class SymbolStore
     scopeChain = @getTokenScopeChain(token)
     wordRegex = @wordRegexForScopeDescriptor(token.scopes)
     matches = text.match(wordRegex)
+    console.log 'matching', text
     if matches?
       @addSymbol(symbolText, bufferPath, bufferRow, scopeChain) for symbolText in matches
     return
@@ -198,6 +200,7 @@ class SymbolStore
   ###
 
   addSymbol: (symbolText, bufferPath, bufferRow, scopeChain) ->
+    console.log 'adding', symbolText
     symbolKey = @getKey(symbolText)
     symbol = @symbolMap[symbolKey]
     unless symbol?
@@ -207,6 +210,7 @@ class SymbolStore
     symbol.addInstance(bufferPath, bufferRow, scopeChain)
 
   removeSymbol: (symbolText, bufferPath, bufferRow, scopeChain) =>
+    console.log 'rem', symbolText
     symbolKey = @getKey(symbolText)
     symbol = @symbolMap[symbolKey]
     if symbol?

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -256,6 +256,30 @@ describe 'SymbolProvider', ->
       results = suggestionsForPrefix(provider, editor, 'item')
       expect(results[0]).toBe 'items'
 
+  fdescribe "when the language specifies an autocomplete.symbolPattern pattern", ->
+    beforeEach ->
+      editor.setText '''
+        var $myvar = 'ok'
+        my
+      '''
+
+    it "calls console.error when the pattern is invalid", ->
+      atom.config.set('autocomplete.symbolPattern', '([a-z]', scopeSelector: '.source.js')
+      spyOn(console, 'error')
+      provider.buildSymbolList(editor)
+      expect(console.error).toHaveBeenCalled()
+      arg = console.error.mostRecentCall.args[0]
+      expect(arg).toContain('`([a-z]`')
+
+    it "uses the config for the scope under the cursor", ->
+      atom.config.set('autocomplete.symbolPattern', '[$][a-z]+', scopeSelector: '.source.js')
+      provider.buildSymbolList(editor)
+
+      editor.setCursorBufferPosition([1, 2])
+      suggestions = suggestionsForPrefix(provider, editor, '$', raw: true)
+      expect(suggestions).toHaveLength 1
+      expect(suggestions[0].text).toBe '$myvar'
+
   describe "when the completions changes between scopes", ->
     beforeEach ->
       editor.setText '''

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -173,6 +173,21 @@ describe 'SymbolStore', ->
       expect(symbols[0].text).toBe 'abc'
       expect(symbols[0].type).toBe 'newtype'
 
+  describe "when different word regexes are specified", ->
+    it "adds tokens matching the scopeDescriptor", ->
+      scopeDescriptor = editor.getRootScopeDescriptor()
+      store.setWordRegexForScopeDescriptor(scopeDescriptor, /[$@][a-z]+/)
+
+      editor.setText('abc @def .ghi $klm\n$klm')
+      expect(store.getLength()).toBe 2
+      expect(store.getSymbol('@def').getCount()).toBe 1
+      expect(store.getSymbol('$klm').getCount()).toBe 2
+
+      editor.setText('abc @def .ghi $klm')
+      expect(store.getLength()).toBe 2
+      expect(store.getSymbol('@def').getCount()).toBe 1
+      expect(store.getSymbol('$klm').getCount()).toBe 1
+
   describe "when there are multiple files with tokens in the store", ->
     config = null
     beforeEach ->


### PR DESCRIPTION
:no_entry_sign: WIP; This probably wont get merged soon...

I want the symbol provider to pick up variables and selectors with the prefixed char, `@`, `.`, etc. So

```less
// variables
@colorGreen: #008000;
@colorGreenDark: darken($colorGreen, 10);

#someid .someclass {
}
```

With this, you should be able to

```
type: `@`
complete: ['@colorGreen', '@colorGreenDark']

type: `.`
complete: ['.someclass']

type: `#`
complete: ['#someid']
```

This PR makes the `SymbolProvider` accept the following config: 

```coffee
'.source.sass, .source.css.scss':
  'autocomplete':
    'symbolPattern': '[\\.\\#$][a-zA-Z][a-zA-Z0-9_-]+'
    'symbolPrefixPattern': '[\\.\\#$]([a-zA-Z][a-zA-Z0-9_-]*)?$'
```

There is one deal breaking issue: in the case of the selectors, the grammars split the `#` and the `someid` into different tokens. Right now, the word regex is run on each token, so the above config will never match the ids or classes.

One option: run the regex on the entire line, walk the participating tokens, and find the common scopes, store the symbol with those scopes. That, of course, adds complexity.

This turned out to be more effort and complexity than I originally thought, so probably punting until after ac+ is the default in core.