### PR TITLE
Change licenses field to license

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,7 @@
   "main": "./lib/main",
   "description": "Display possible completions in the editor while typing",
   "repository": "https://github.com/atom/autocomplete-plus",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/autocomplete-plus/raw/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "atom": ">=0.189.0 <2.0.0"
   },


### PR DESCRIPTION
This changes `licenses` to `license` in `package.json` as this is what npm's (and what we're now using) `normalize-package-data` expects. Atom specs will now fail without it :grin: 