### PR TITLE
Check all cursors (not just last) when deciding whether to activate

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -438,16 +438,24 @@ class AutocompleteManager
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
     shouldActivate = false
-    cursorBufferPosition = @editor.getLastCursor().getBufferPosition()
+    cursorPositions = @editor.getCursorBufferPositions()
 
     if @autoActivationEnabled or @suggestionList.isActive()
-      if newText?.length and newRange.containsPoint(cursorBufferPosition)
-        # Activate on space, a non-whitespace character, or a bracket-matcher pair
-        shouldActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
-      else if oldText?.length and (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldRange.containsPoint(cursorBufferPosition)
-        # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
-        # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
-        shouldActivate = oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs
+
+      # Activate on space, a non-whitespace character, or a bracket-matcher pair.
+      if newText.length > 0
+        shouldActivate =
+          (cursorPositions.some (position) -> newRange.containsPoint(position)) and
+          (newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs)
+
+      # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur.
+      # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair.
+      else if oldText.length > 0
+        shouldActivate =
+          (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and
+          (cursorPositions.some (position) -> newRange.containsPoint(position)) and
+          (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
+
       shouldActivate = false if shouldActivate and @shouldSuppressActivationForEditorClasses()
 
     if shouldActivate


### PR DESCRIPTION
This is to fix some breakage against Atom master. Recent [changes](https://github.com/atom/text-buffer/pull/58) to `text-buffer` have affected the order in which markers' `onDidChange` events are emitted, relative to the buffer's `onDidChange` event. Now, marker events are always emitted after buffer events. At first I interpreted this as a bug in `text-buffer`, but now I don't think it is.

This package uses the `Cursor::onDidChangePosition` and `Buffer::onDidChange` hooks to show and hide the autocomplete view, in a way that depends on the order in which they occur. I don't fully understand the chain of events (maybe @joefitzgerald or @benogle will understand this better) but I found that in some cases, in the `Buffer::onDidChange` handler, we were deciding *not* to show the autocomplete view because the cursor that inserted the text was not the last cursor. I found checking all of the cursors (not just the last one) fixed the behavior.