### PR TITLE
Use token iterator rather than tokens shim on TokenizedLine if available

### DIFF
--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -251,24 +251,9 @@ class SymbolProvider
     _.defer => @buildSymbolList(editor)
 
   buildSymbolList: (editor) =>
-    return unless editor?
+    return unless editor?.isAlive()
     @symbolStore.clear(editor.getPath())
-    @cacheSymbolsFromEditor(editor)
-
-  cacheSymbolsFromEditor: (editor, tokenizedLines) ->
-    tokenizedLines ?= @getTokenizedLines(editor)
-
-    bufferPath = editor.getPath()
-    for {tokens}, bufferRow in tokenizedLines
-      for token in tokens
-        @symbolStore.addToken(token, bufferPath, bufferRow, @minimumWordLength)
-    return
-
-  getTokenizedLines: (editor) ->
-    # Warning: displayBuffer and tokenizedBuffer are private APIs. Please do not
-    # copy into your own package. If you do, be prepared to have it break
-    # without warning.
-    editor.displayBuffer.tokenizedBuffer.tokenizedLines
+    @symbolStore.addTokensInBufferRange(editor, editor.getBuffer().getRange())
 
   # FIXME: this should go in the core ScopeDescriptor class
   scopeDescriptorsEqual: (a, b) ->

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -178,14 +178,14 @@ describe 'SymbolStore', ->
     beforeEach ->
       config = stuff: selectors: Selector.create('.source')
 
-      store.addToken({value: 'one', scopes: ['source.coffee']}, 'one.txt', 1)
-      store.addToken({value: 'ok', scopes: ['source.coffee']}, 'one.txt', 1)
-      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
-      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
+      store.addToken('one', '.source.coffee', 'one.txt', 1)
+      store.addToken('ok', '.source.coffee', 'one.txt', 1)
+      store.addToken('wow', '.source.coffee', 'one.txt', 2)
+      store.addToken('wow', '.source.coffee', 'one.txt', 2)
 
-      store.addToken({value: 'two', scopes: ['source.coffee']}, 'two.txt', 1)
-      store.addToken({value: 'ok', scopes: ['source.coffee']}, 'two.txt', 1)
-      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'two.txt', 2)
+      store.addToken('two', '.source.coffee', 'two.txt', 1)
+      store.addToken('ok', '.source.coffee', 'two.txt', 1)
+      store.addToken('wow', '.source.coffee', 'two.txt', 2)
 
     describe "when a path changes", ->
       it "returns the symbols transferred to the new path", ->


### PR DESCRIPTION
This doesn’t add much speed, but it avoids the allocation of arrays of temporary token objects which should avoid GC pauses. It will work on version of Atom where the token iterator is available on TokenizedLine (see atom/atom#6757)… otherwise it falls back to the `tokens` property.

/cc @benogle