### PR TITLE
Add setting to allow for remapping of keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,40 @@ Press `UP` and `DOWN` to select another suggestion, press `TAB` or `ENTER` to co
 
 * Keymap For Confirming A Suggestion
 
-Additionally, the keymap can be customized in your keymap.cson:
+Additionally, the confirm keymap can be customized in your keymap.cson:
 
 ```coffeescript
-'atom-text-editor:not(mini).autocomplete-active':
+'atom-text-editor.autocomplete-active':
   'tab': 'unset!'
-  'enter': 'autocomplete-plus:confirm'
-  'up': 'unset!'
-  'down': 'unset!'
-  'ctrl-p': 'core:move-up'
-  'ctrl-n': 'core:move-down'
+  'ctrl-shift-a': 'autocomplete-plus:confirm'
+```
+
+### Remapping Movement Commands
+
+By default, autocomplete-plus commandeers the editor's core movement commands when the suggestion list is open. You may want to change these movement commands to use your own keybindings.
+
+First you need to set the `autocomplete-plus.useCoreMovementCommands` setting to `false`, which you can do from the `autocomplete-plus` settings in the settings view.
+
+![core-movement](https://cloud.githubusercontent.com/assets/69169/8839134/72a9c7e6-3087-11e5-9d1f-8d3d15961327.jpg)
+
+Or by adding this to your config file:
+
+```coffee
+"*":
+  "autocomplete-plus":
+    "useCoreMovementCommands": false
+```
+
+Then add these to your keymap file:
+
+```coffeescript
+'body atom-text-editor.autocomplete-active':
+  'ctrl-p': 'autocomplete-plus:move-up'
+  'ctrl-n': 'autocomplete-plus:move-down'
+  'pageup': 'autocomplete-plus:page-up'
+  'pagedown': 'autocomplete-plus:page-down'
+  'home': 'autocomplete-plus:move-to-top'
+  'end': 'autocomplete-plus:move-to-bottom'
 ```
 
 ## Features

--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -1,2 +1,5 @@
 'atom-text-editor':
   'ctrl-space': 'autocomplete-plus:activate'
+
+'atom-text-editor.autocomplete-active':
+  'escape': 'autocomplete-plus:cancel'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,12 @@ module.exports =
       default: 'tab and enter'
       enum: ['tab', 'enter', 'tab and enter']
       order: 4
+    useCoreMovementCommands:
+      title: 'Use Core Movement Commands'
+      description: 'Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/atom/autocomplete-plus#usage'
+      type: 'boolean'
+      default: true
+      order: 5
     fileBlacklist:
       title: 'File Blacklist'
       description: 'Suggestions will not be provided for files matching this list, e.g. *.md for Markdown files.'
@@ -35,7 +41,7 @@ module.exports =
       default: ['.*']
       items:
         type: 'string'
-      order: 5
+      order: 6
     scopeBlacklist:
       title: 'Scope Blacklist'
       description: 'Suggestions will not be provided for scopes matching this list. See: https://atom.io/docs/latest/behind-atom-scoped-settings-scopes-and-scope-descriptors'
@@ -43,55 +49,55 @@ module.exports =
       default: []
       items:
         type: 'string'
-      order: 6
+      order: 7
     includeCompletionsFromAllBuffers:
       title: 'Include Completions From All Buffers'
       description: 'For grammars with no registered provider(s), the default provider will include completions from all buffers, instead of just the buffer you are currently editing.'
       type: 'boolean'
       default: true
-      order: 7
+      order: 8
     strictMatching:
       title: 'Use Strict Matching For Built-In Provider'
       description: 'Fuzzy searching is performed if this is disabled; if it is enabled, suggestions must begin with the prefix from the current word.'
       type: 'boolean'
       default: false
-      order: 8
+      order: 9
     minimumWordLength:
       description: "Only autocomplete when you've typed at least this many characters."
       type: 'integer'
       default: 3
-      order: 9
+      order: 10
     enableBuiltinProvider:
       title: 'Enable Built-In Provider'
       description: 'The package comes with a built-in provider that will provide suggestions using the words in your current buffer or all open buffers. You will get better suggestions by installing additional autocomplete+ providers. To stop using the built-in provider, disable this option.'
       type: 'boolean'
       default: true
-      order: 10
+      order: 11
     builtinProviderBlacklist:
       title: 'Built-In Provider Blacklist'
       description: 'Don\'t use the built-in provider for these selector(s).'
       type: 'string'
       default: '.source.gfm'
-      order: 11
+      order: 12
     backspaceTriggersAutocomplete:
       title: 'Allow Backspace To Trigger Autocomplete'
       description: 'If enabled, typing `backspace` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while backspacing.'
       type: 'boolean'
       default: false
-      order: 12
+      order: 13
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appears at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Word'
       enum: ['Word', 'Cursor']
-      order: 13
+      order: 14
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Symbol'
       enum: ['Fuzzy', 'Symbol']
-      order: 14
+      order: 15
     suppressActivationForEditorClasses:
       title: 'Suppress Activation For Editor Classes'
       description: 'Don\'t auto-activate when any of these classes are present in the editor.'
@@ -99,7 +105,7 @@ module.exports =
       default: ['vim-mode.command-mode', 'vim-mode.visual-mode', 'vim-mode.operator-pending-mode']
       items:
         type: 'string'
-      order: 15
+      order: 16
 
   autocompleteManager: null
   subscriptions: null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -30,7 +30,7 @@ module.exports =
       order: 4
     useCoreMovementCommands:
       title: 'Use Core Movement Commands'
-      description: 'Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/atom/autocomplete-plus#usage'
+      description: 'Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/atom/autocomplete-plus#remapping-movement-commands'
       type: 'boolean'
       default: true
       order: 5

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -11,30 +11,41 @@ class SuggestionList
     @subscriptions.add atom.commands.add 'atom-text-editor.autocomplete-active',
       'autocomplete-plus:confirm': @confirmSelection,
       'autocomplete-plus:cancel': @cancel
-      'core:move-up': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectPrevious()
-          event.stopImmediatePropagation()
-      'core:move-down': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectNext()
-          event.stopImmediatePropagation()
-      'core:page-up': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectPageUp()
-          event.stopImmediatePropagation()
-      'core:page-down': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectPageDown()
-          event.stopImmediatePropagation()
-      'core:move-to-top': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectTop()
-          event.stopImmediatePropagation()
-      'core:move-to-bottom': (event) =>
-        if @isActive() and @items?.length > 1
-          @selectBottom()
-          event.stopImmediatePropagation()
+    @subscriptions.add atom.config.observe 'autocomplete-plus.useCoreMovementCommands', => @bindToMovementCommands()
+
+  bindToMovementCommands: ->
+    useCoreMovementCommands = atom.config.get('autocomplete-plus.useCoreMovementCommands')
+    commandNamespace = if useCoreMovementCommands then 'core' else 'autocomplete-plus'
+
+    commands = {}
+    commands["#{commandNamespace}:move-up"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectPrevious()
+        event.stopImmediatePropagation()
+    commands["#{commandNamespace}:move-down"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectNext()
+        event.stopImmediatePropagation()
+    commands["#{commandNamespace}:page-up"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectPageUp()
+        event.stopImmediatePropagation()
+    commands["#{commandNamespace}:page-down"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectPageDown()
+        event.stopImmediatePropagation()
+    commands["#{commandNamespace}:move-to-top"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectTop()
+        event.stopImmediatePropagation()
+    commands["#{commandNamespace}:move-to-bottom"] = (event) =>
+      if @isActive() and @items?.length > 1
+        @selectBottom()
+        event.stopImmediatePropagation()
+
+    @movementCommandSubscriptions?.dispose()
+    @movementCommandSubscriptions = new CompositeDisposable
+    @movementCommandSubscriptions.add atom.commands.add('atom-text-editor.autocomplete-active', commands)
 
   addKeyboardInteraction: ->
     @removeKeyboardInteraction()
@@ -185,5 +196,6 @@ class SuggestionList
   # Public: Clean up, stop listening to events
   dispose: ->
     @subscriptions.dispose()
+    @movementCommandSubscriptions?.dispose()
     @emitter.emit('did-dispose')
     @emitter.dispose()

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -49,11 +49,9 @@ class SuggestionList
 
   addKeyboardInteraction: ->
     @removeKeyboardInteraction()
-    keys =
-      'escape': 'autocomplete-plus:cancel'
-
     completionKey = atom.config.get('autocomplete-plus.confirmCompletion') or ''
 
+    keys = {}
     keys['tab'] = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
     keys['enter'] = 'autocomplete-plus:confirm' if completionKey.indexOf('enter') > -1
 

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -627,6 +627,67 @@ describe 'Autocomplete Manager', ->
             expect(newWidth).toBeGreaterThan 0
             expect(newWidth).toBeLessThan listWidth
 
+    describe "when number of useCoreMovementCommands is toggled", ->
+      [suggestionList] = []
+
+      beforeEach ->
+        triggerAutocompletion(editor, true, 'a')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+
+      it "binds to custom commands when unset, and binds back to core commands when set", ->
+        atom.commands.dispatch(suggestionList, 'core:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[1]).toHaveClass 'selected'
+
+        atom.config.set('autocomplete-plus.useCoreMovementCommands', false)
+
+        atom.commands.dispatch(suggestionList, 'core:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[1]).toHaveClass 'selected'
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[2]).toHaveClass 'selected'
+
+        atom.config.set('autocomplete-plus.useCoreMovementCommands', true)
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[2]).toHaveClass 'selected'
+        atom.commands.dispatch(suggestionList, 'core:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[3]).toHaveClass 'selected'
+
+    describe "when number of useCoreMovementCommands is false", ->
+      [suggestionList] = []
+
+      beforeEach ->
+        atom.config.set('autocomplete-plus.useCoreMovementCommands', false)
+        triggerAutocompletion(editor, true, 'a')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+
+      it "responds to all the custom movement commands and to no core commands", ->
+        atom.commands.dispatch(suggestionList, 'core:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[0]).toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[1]).toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-up')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[0]).toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:page-down')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[0]).not.toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:page-up')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[0]).toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-to-bottom')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[3]).toHaveClass 'selected'
+
+        atom.commands.dispatch(suggestionList, 'autocomplete-plus:move-to-top')
+        expect(editorView.querySelectorAll('.autocomplete-plus li')[0]).toHaveClass 'selected'
+
     describe "when match.snippet is used", ->
       beforeEach ->
         spyOn(provider, 'getSuggestions').andCallFake ({prefix}) ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -6,6 +6,7 @@ beforeEach ->
   atom.config.set('autocomplete-plus.defaultProvider', 'Symbol')
   atom.config.set('autocomplete-plus.minimumWordLength', 1)
   atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
+  atom.config.set('autocomplete-plus.useCoreMovementCommands', true)
   atom.config.set('autocomplete-plus.includeCompletionsFromAllBuffers', false)
 
 exports.triggerAutocompletion = (editor, moveCursor = true, char = 'f') ->


### PR DESCRIPTION
The instructions in the readme dont work for people who want to remap the movement commands. `unset!` doesnt actually do what users want, so up/down, and the others are not able to be remapped. This PR adds a `useCoreMovementCommands` setting that will listen for `autocomplete-plus:*` commands rather than `core:*` events when disabled. Instructions also added to the readme. 

cc @joefitzgerald @lee-dohm I know people have problems with this, and this is an attempt to give folks a clean way to remap.