### PR TITLE
Avoid implicit list comprehension in Symbol.symbolsForConfig

### DIFF
--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -104,6 +104,7 @@ class Symbol
             if (not @type or options.typePriority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
               @type = type
               typePriority = options.typePriority
+          return
       @cachedConfig = config
 
     if buffer?


### PR DESCRIPTION
<img width="935" alt="screenshot 2015-09-09 09 30 06" src="https://cloud.githubusercontent.com/assets/1276728/9768535/26a2b588-56d9-11e5-8fa1-d88cc1fb5b7f.png">

I've recently been experiencing multi-second pauses in longer-running Atom sessions (or possibly sessions with large numbers of open files). I'm unable to reproduce shortly after restarting, so the primary cause of my pauses is likely elsewhere. However, the attached fix seems to help significantly. The source of the pause in the attached profile is [implicit list comprehensions](https://github.com/jashkenas/coffeescript/issues/896).

The inner loop of `Symbol.appliesToConfig` looks like this:
```coffeescript
@metadataByPath.forEach ({scopeChains}) =>
  for scopeChain, __ of scopeChains
    if (not @type or options.typePriority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
      @type = type
      typePriority = options.typePriority
```
and compiles to this:
```javascript
this.metadataByPath.forEach((function(_this) {
  return function(arg) {
    var __, results, scopeChain, scopeChains, typePriority;
    scopeChains = arg.scopeChains;
    results = [];
    for (scopeChain in scopeChains) {
      __ = scopeChains[scopeChain];
      if ((!_this.type || options.typePriority > typePriority) && selectorsMatchScopeChain(options.selectors, scopeChain)) {
        _this.type = type;
        results.push(typePriority = options.typePriority);
      } else {
        results.push(void 0);
      }
    }
    return results;
  };
})(this));
```

notice the `results` array that ends up being discarded. adding an implicit return to the end of the loop:
```diff
 @metadataByPath.forEach ({scopeChains}) =>
   ...
+  undefined
```
compiles into something more agreeable:
```javascript
this.metadataByPath.forEach((function(_this) {
  return function(arg) {
    var __, scopeChain, scopeChains, typePriority;
    scopeChains = arg.scopeChains;
    for (scopeChain in scopeChains) {
      __ = scopeChains[scopeChain];
      if ((!_this.type || options.typePriority > typePriority) && selectorsMatchScopeChain(options.selectors, scopeChain)) {
        _this.type = type;
        typePriority = options.typePriority;
      }
    }
    return void 0;
  };
})(this));
```