### PR TITLE
Cache and micro-optimize suggestion generation in SymbolProvider

### DIFF
--- a/lib/scope-helpers.coffee
+++ b/lib/scope-helpers.coffee
@@ -2,16 +2,39 @@ slick = require 'atom-slick'
 
 EscapeCharacterRegex = /[-!"#$%&'*+,/:;=?@|^~()<>{}[\]]/g
 
+cachedMatchesBySelector = new WeakMap
+
+getCachedMatch = (selector, scopeChain) ->
+  if cachedMatchesByScopeChain = cachedMatchesBySelector.get(selector)
+    return cachedMatchesByScopeChain[scopeChain]
+
+setCachedMatch = (selector, scopeChain, match) ->
+  unless cachedMatchesByScopeChain = cachedMatchesBySelector.get(selector)
+    cachedMatchesByScopeChain = {}
+    cachedMatchesBySelector.set(selector, cachedMatchesByScopeChain)
+  cachedMatchesByScopeChain[scopeChain] = match
+
 parseScopeChain = (scopeChain) ->
   scopeChain = scopeChain.replace EscapeCharacterRegex, (match) -> "\\#{match[0]}"
   scope for scope in slick.parse(scopeChain)[0] ? []
 
 selectorForScopeChain = (selectors, scopeChain) ->
   for selector in selectors
-    scopes = parseScopeChain(scopeChain)
-    while scopes.length > 0
-      return selector if selector.matches(scopes)
-      scopes.pop()
+    cachedMatch = getCachedMatch(selector, scopeChain)
+    if cachedMatch?
+      if cachedMatch
+        return selector
+      else
+        continue
+    else
+      scopes = parseScopeChain(scopeChain)
+      while scopes.length > 0
+        if selector.matches(scopes)
+          setCachedMatch(selector, scopeChain, true)
+          return selector
+        scopes.pop()
+      setCachedMatch(selector, scopeChain, false)
+
   null
 
 selectorsMatchScopeChain = (selectors, scopeChain) ->

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -97,10 +97,11 @@ class Symbol
 
     unless @type?
       typePriority = 0
-      for type, options of config
+      for type in Object.keys(config)
+        options = config[type]
         continue unless options.selectors?
         @metadataByPath.forEach ({scopeChains}) =>
-          for scopeChain, __ of scopeChains
+          for scopeChain in Object.keys(scopeChains)
             if (not @type or options.typePriority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
               @type = type
               typePriority = options.typePriority
@@ -136,7 +137,8 @@ class SymbolStore
 
   symbolsForConfig: (config, buffer, wordUnderCursor, numberOfCursors) ->
     symbols = []
-    for symbolKey, symbol of @symbolMap
+    for symbolKey in Object.keys(@symbolMap)
+      symbol = @symbolMap[symbolKey]
       if symbol.appliesToConfig(config, buffer) and (not symbol.isEqualToWord(wordUnderCursor) or symbol.instancesForWord(wordUnderCursor) > numberOfCursors)
         symbols.push(symbol)
     for type, options of config


### PR DESCRIPTION
When we have a large number of symbols in the symbol store due to a large file being opened and tokenized, computing suggestions gets expensive due to matching selectors in the symbols against the current scope in a tight loop. Long term, we need to compute the type of a symbol once upon insertion into the symbol store, but this PR caches the selector matches to at least minimize the work being performed in the loop on subsequent completions for the same scope.

This profile was performed by opening `text-editor-spec.coffee` and `huge.js` in an editor and allowing both to tokenize. Then I typed at the end of the file, typed in a string to bust the existing caching, then switched back to the end of the file and typed more. With the new caching, subsequent completions are about ~5x faster, from ~100ms to ~20ms. This could be even faster if we used a smarter approach to index these symbols, but this is a good start.

### Before

![screen shot 2015-09-17 at 2 24 02 pm](https://cloud.githubusercontent.com/assets/1789/9945078/6a6c1fe6-5d48-11e5-914c-31ee201a26f0.png)

### After

![screen shot 2015-09-17 at 2 23 38 pm](https://cloud.githubusercontent.com/assets/1789/9945084/73520e72-5d48-11e5-8aaa-267667d6fd46.png)

/cc @benogle @maxbrunsfeld