### PR TITLE
Add 'enableAutoConfirmSingleSuggestion' setting

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -15,6 +15,7 @@ module.exports =
 class AutocompleteManager
   autosaveEnabled: false
   backspaceTriggersAutocomplete: true
+  autoConfirmSingleSuggestionEnabled: true
   bracketMatcherPairs: ['()', '[]', '{}', '""', "''", '``', "“”", '‘’', "«»", "‹›"]
   buffer: null
   compositionInProgress: false
@@ -102,6 +103,7 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autosave.enabled', (value) => @autosaveEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => @autoConfirmSingleSuggestionEnabled = value))
     @subscriptions.add atom.config.observe 'autocomplete-plus.fileBlacklist', (value) =>
       @fileBlacklist = value?.map((s) -> s.trim())
       @isCurrentFileBlackListedCache = null
@@ -196,7 +198,7 @@ class AutocompleteManager
       .then(@mergeSuggestionsFromProviders)
       .then (suggestions) =>
         return unless @currentSuggestionsPromise is suggestionsPromise
-        if options.activatedManually and @shouldDisplaySuggestions and suggestions.length is 1
+        if options.activatedManually and @shouldDisplaySuggestions and @autoConfirmSingleSuggestionEnabled and suggestions.length is 1
           # When there is one suggestion in manual mode, just confirm it
           @confirm(suggestions[0])
         else

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -85,19 +85,25 @@ module.exports =
       type: 'boolean'
       default: false
       order: 13
+    enableAutoConfirmSingleSuggestion:
+      title: 'Automatically Confirm Single Suggestion'
+      description: 'If enabled, automatically insert suggestion on manual activation with autocomplete-plus:activate when there is only one match.'
+      type: 'boolean'
+      default: true
+      order: 14
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appears at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Word'
       enum: ['Word', 'Cursor']
-      order: 14
+      order: 15
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Symbol'
       enum: ['Fuzzy', 'Symbol']
-      order: 15
+      order: 16
     suppressActivationForEditorClasses:
       title: 'Suppress Activation For Editor Classes'
       description: 'Don\'t auto-activate when any of these classes are present in the editor.'
@@ -105,7 +111,7 @@ module.exports =
       default: ['vim-mode.command-mode', 'vim-mode.visual-mode', 'vim-mode.operator-pending-mode']
       items:
         type: 'string'
-      order: 16
+      order: 17
 
   autocompleteManager: null
   subscriptions: null

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1264,6 +1264,21 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
+      it 'does not accept the suggestion if auto-confirm single suggestion is disabled', ->
+        spyOn(provider, 'getSuggestions').andCallFake (options) ->
+          [text: 'omgok']
+
+        triggerAutocompletion(editor)
+
+        runs ->
+          atom.config.set('autocomplete-plus.enableAutoConfirmSingleSuggestion', false)
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
       it 'includes the correct value for activatedManually when explicitly triggered', ->
         spyOn(provider, 'getSuggestions').andCallFake (o) ->
           options = o


### PR DESCRIPTION
Allows disabling automatic confirm a singular suggestion when in manual
mode. Useful if this match is wrong or using manual completion to see
function signature.