### PR TITLE
Adding an option to toggle the consumption of suffix characters

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -104,7 +104,7 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => @autoConfirmSingleSuggestionEnabled = value))
-    @subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffixWords', (value) => @consumeSuffixWords = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffix', (value) => @consumeSuffix = value))
     @subscriptions.add atom.config.observe 'autocomplete-plus.fileBlacklist', (value) =>
       @fileBlacklist = value?.map((s) -> s.trim())
       @isCurrentFileBlackListedCache = null
@@ -376,7 +376,7 @@ class AutocompleteManager
         beginningPosition = [endPosition.row, endPosition.column - suggestion.replacementPrefix.length]
 
         if @editor.getTextInBufferRange([beginningPosition, endPosition]) is suggestion.replacementPrefix
-          suffix = if @consumeSuffixWords then @getSuffix(@editor, endPosition, suggestion) else ''
+          suffix = if @consumeSuffix then @getSuffix(@editor, endPosition, suggestion) else ''
           cursor.moveRight(suffix.length) if suffix.length
           cursor.selection.selectLeft(suggestion.replacementPrefix.length + suffix.length)
 

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -104,6 +104,7 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => @autoConfirmSingleSuggestionEnabled = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffixWords', (value) => @consumeSuffixWords = value))
     @subscriptions.add atom.config.observe 'autocomplete-plus.fileBlacklist', (value) =>
       @fileBlacklist = value?.map((s) -> s.trim())
       @isCurrentFileBlackListedCache = null
@@ -375,7 +376,7 @@ class AutocompleteManager
         beginningPosition = [endPosition.row, endPosition.column - suggestion.replacementPrefix.length]
 
         if @editor.getTextInBufferRange([beginningPosition, endPosition]) is suggestion.replacementPrefix
-          suffix = @getSuffix(@editor, endPosition, suggestion)
+          suffix = if @consumeSuffixWords then @getSuffix(@editor, endPosition, suggestion) else ''
           cursor.moveRight(suffix.length) if suffix.length
           cursor.selection.selectLeft(suggestion.replacementPrefix.length + suffix.length)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -112,9 +112,9 @@ module.exports =
       items:
         type: 'string'
       order: 17
-    consumeSuffixWords:
+    consumeSuffix:
       title: 'Consume suggestion text following the cursor'
-      description: 'Completing a suggestion will delete all identical text after the cursor'
+      description: 'Completing a suggestion consumes text following the cursor matching the suffix of the chosen suggestion.'
       type: 'boolean'
       default: true
       order: 18

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -112,6 +112,12 @@ module.exports =
       items:
         type: 'string'
       order: 17
+    consumeSuffixWords:
+      title: 'Consume suggestion text following the cursor'
+      description: 'Completing a suggestion will delete all identical text after the cursor'
+      type: 'boolean'
+      default: true
+      order: 18
 
   autocompleteManager: null
   subscriptions: null

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -24,7 +24,7 @@ describe 'Autocomplete Manager', ->
       jasmine.attachToDOM(workspaceElement)
 
       atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
-      atom.config.set('autocomplete-plus.consumeSuffixWords', true)
+      atom.config.set('autocomplete-plus.consumeSuffix', true)
 
   describe "when an external provider is registered", ->
     [provider] = []
@@ -1180,8 +1180,8 @@ describe 'Autocomplete Manager', ->
 
             expect(editor.getText()).toBe 'oneomgtwothree'
 
-        it 'does not replace the suffix text when consumeSuffixWords is disabled', ->
-          atom.config.set('autocomplete-plus.consumeSuffixWords', false)
+        it 'does not replace the suffix text when consumeSuffix is disabled', ->
+          atom.config.set('autocomplete-plus.consumeSuffix', false)
 
           editor.setText('ontwothree')
           editor.setCursorBufferPosition([0, 2])
@@ -1192,7 +1192,6 @@ describe 'Autocomplete Manager', ->
             atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
             expect(editor.getText()).toBe 'oneomgtwotwothree'
-
 
       describe "when the cursor suffix does not match the replacement", ->
         beforeEach ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -24,6 +24,7 @@ describe 'Autocomplete Manager', ->
       jasmine.attachToDOM(workspaceElement)
 
       atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
+      atom.config.set('autocomplete-plus.consumeSuffixWords', true)
 
   describe "when an external provider is registered", ->
     [provider] = []
@@ -1178,6 +1179,20 @@ describe 'Autocomplete Manager', ->
             atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
             expect(editor.getText()).toBe 'oneomgtwothree'
+
+        it 'does not replace the suffix text when consumeSuffixWords is disabled', ->
+          atom.config.set('autocomplete-plus.consumeSuffixWords', false)
+
+          editor.setText('ontwothree')
+          editor.setCursorBufferPosition([0, 2])
+          triggerAutocompletion(editor, false, 'e')
+
+          runs ->
+            suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+
+            expect(editor.getText()).toBe 'oneomgtwotwothree'
+
 
       describe "when the cursor suffix does not match the replacement", ->
         beforeEach ->


### PR DESCRIPTION
Adds the option:

![image](https://cloud.githubusercontent.com/assets/320562/10012004/8aeb6448-6135-11e5-9975-86219ed12433.png)

Which, when disabled, ignores any suffix text.

Closes #468
Closes #559