### PR TITLE
Use fuzzaldrin-plus as an option

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -2,6 +2,7 @@
 path = require 'path'
 semver = require 'semver'
 fuzzaldrin = require 'fuzzaldrin'
+fuzzaldrinPlus = require 'fuzzaldrin-plus'
 
 ProviderManager = require './provider-manager'
 SuggestionList = require './suggestion-list'
@@ -105,6 +106,7 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => @autoConfirmSingleSuggestionEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffix', (value) => @consumeSuffix = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', (value) => @useAlternateScoring = value ))
     @subscriptions.add atom.config.observe 'autocomplete-plus.fileBlacklist', (value) =>
       @fileBlacklist = value?.map((s) -> s.trim())
       @isCurrentFileBlackListedCache = null
@@ -207,6 +209,7 @@ class AutocompleteManager
 
   filterSuggestions: (suggestions, {prefix}) ->
     results = []
+    fuzzaldrinProvider = if @useAlternateScoring then fuzzaldrinPlus else fuzzaldrin
     for suggestion, i in suggestions
       # sortScore mostly preserves in the original sorting. The function is
       # chosen such that suggestions with a very high match score can break out.
@@ -220,7 +223,7 @@ class AutocompleteManager
 
       if prefixIsEmpty
         results.push(suggestion)
-      if firstCharIsMatch and (score = fuzzaldrin.score(text, suggestionPrefix)) > 0
+      if firstCharIsMatch and (score = fuzzaldrinProvider.score(text, suggestionPrefix)) > 0
         suggestion.score = score * suggestion.sortScore
         results.push(suggestion)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -123,8 +123,8 @@ module.exports =
       type: 'boolean'
       default: false
       order: 19
-    useBufferProximity:
-      description: "Prefers words that are closer to insertion point"
+    useLocalityBonus:
+      description: "Gives words near the cursor position a higher score than those far away"
       type: 'boolean'
       default: true
       order: 20

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -118,6 +118,16 @@ module.exports =
       type: 'boolean'
       default: true
       order: 18
+    useAlternateScoring:
+      description: "Prefers runs of consecutive characters, acronyms and start of words. (Experimental)"
+      type: 'boolean'
+      default: false
+      order: 19
+    useBufferProximity:
+      description: "Prefers words that are closer to insertion point"
+      type: 'boolean'
+      default: true
+      order: 20
 
   autocompleteManager: null
   subscriptions: null

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -403,8 +403,8 @@ class SuggestionListElement extends HTMLElement
     return unless text?.length and replacementPrefix?.length
     matches = {}
     if @useAlternateScoring
-      fpm = fuzzaldrinPlus.match(text, replacementPrefix)
-      matches[pos] = true for pos in fpm
+      matchIndices = fuzzaldrinPlus.match(text, replacementPrefix)
+      matches[i] = true for i in matchIndices
     else
       wordIndex = 0
       for ch, i in replacementPrefix

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -216,8 +216,8 @@ class SymbolProvider
       # Uppercase, lowercase and a version of prefix without optional characters.
       prefixCache = fuzzaldrinPlus.prepQuery(prefix)
     else
-     fuzzaldrinProvider = fuzzaldrin
-     prefixCache = null
+      fuzzaldrinProvider = fuzzaldrin
+      prefixCache = null
 
     for symbol in symbolList
       text = (symbol.snippet or symbol.text)
@@ -239,7 +239,7 @@ class SymbolProvider
   getLocalityScore: (bufferPosition, bufferRowsContainingSymbol) ->
     if bufferRowsContainingSymbol?
       rowDifference = Number.MAX_VALUE
-      rowDifference = Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol
+      rowDifference = (Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol)
       locality = @computeLocalityModifier(rowDifference)
       locality
     else

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -247,8 +247,16 @@ class SymbolProvider
 
   computeLocalityModifier: (rowDifference) ->
     rowDifference = Math.abs(rowDifference)
-    # Will be between 1 and ~2.75
-    1 + Math.max(-Math.pow(.2 * rowDifference - 3, 3) / 25 + .5, 0)
+    if @useAlternateScoring
+      # Between 1 and 1 + strength. (here between 1.0 and 2.0)
+      # Avoid a pow and a branching max.
+      # 25 is the number of row where the bonus is 3/4 faded away.
+      # strength is the factor in front of fade*fade. Here it is 1.0
+      fade = 25.0/(25.0+rowDifference)
+      1.0 + fade*fade
+    else
+      # Will be between 1 and ~2.75
+      1 + Math.max(-Math.pow(.2 * rowDifference - 3, 3) / 25 + .5, 0)
 
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
     atom.config.getAll(keyPath, scope: scopeDescriptor)

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -239,7 +239,7 @@ class SymbolProvider
   getLocalityScore: (bufferPosition, bufferRowsContainingSymbol) ->
     if bufferRowsContainingSymbol?
       rowDifference = Number.MAX_VALUE
-      rowDifference = (Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol)
+      rowDifference = Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol
       locality = @computeLocalityModifier(rowDifference)
       locality
     else

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "atom-slick": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
+    "fuzzaldrin-plus": "^0.1.0",
     "grim": "^1.4.0",
     "minimatch": "^2.0.1",
     "selector-kit": "^0.1",


### PR DESCRIPTION
Closes https://github.com/atom/autocomplete-plus/issues/586

Add options to the end:
Use Alternative Scoring - disabled by default, use fuzzaldrin-plus.
Use Buffer Proximity - enabled by default, standard locality scoring.

This is done so the tester can see the effect of which is which. 
They are not quite tuned together. 

Example when proximity feel intuitive or not would be helpful, there's no spec for that.
Maybe later proximity strength  can be an option instead of on/off.