### PR TITLE
Round left position to the nearest integer

### DIFF
--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1945,4 +1945,4 @@ describe 'Autocomplete Manager', ->
     left = editorView.pixelPositionForBufferPosition(bufferPosition).left
     left += editorView.offsetLeft
     left = gutterWidth + left if requiresGutter()
-    "#{left}px"
+    "#{Math.round(left)}px"


### PR DESCRIPTION
Refs.: atom/atom#8811

We're enabling subpixel font scaling and, although this package doesn't make use of it directly, some of its tests rely on it, thus breaking in the aforementioned PR. 

Specs fail on atom/atom :x: because we always round positions to the nearest integer. This PR fixes it by always checking for rounded positions.

(AppVeyor is failing for some reason, although [specs are :green_heart: in there as well](https://ci.appveyor.com/project/joefitzgerald/autocomplete-plus/build/725).)

/cc: @nathansobo 