### PR TITLE
Preserve whitespace and newlines in descriptions

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -41,6 +41,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   .suggestion-description-content {
     font-size: @font-size + 1px;
     font-family: @font-family;
+    white-space: pre-wrap;
   }
 
   .suggestion-description-more-link {


### PR DESCRIPTION
This makes reading docstrings much easier.

Before:

![image](https://cloud.githubusercontent.com/assets/81205/10608063/a0878638-773d-11e5-9408-b75fb2da5c5d.png)

After:

![image](https://cloud.githubusercontent.com/assets/81205/10608075/b088e1f8-773d-11e5-98ad-ff63d007af35.png)
