### PR TITLE
bugfix: auto indentation after suggestion confirm

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -386,7 +386,10 @@ class AutocompleteManager
           if suggestion.snippet? and @snippetsManager?
             @snippetsManager.insertSnippet(suggestion.snippet, @editor, cursor)
           else
-            cursor.selection.insertText(suggestion.text ? suggestion.snippet)
+            options = {}
+            options.autoIndentNewline = @editor.shouldAutoIndent()
+            options.autoDecreaseIndent = @editor.shouldAutoIndent()
+            cursor.selection.insertText(suggestion.text ? suggestion.snippet, options)
       return
 
   getSuffix: (editor, bufferPosition, suggestion) ->


### PR DESCRIPTION
Added an instruction to trigger the auto indentation after a suggestion is confirmed. 

(It is a bugfix for [this](https://github.com/atom/autocomplete-plus/issues/610) issue)