### PR TITLE
Use atom.workspace.isTextEditor when available

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -92,9 +92,12 @@ class AutocompleteManager
       @isCurrentFileBlackListedCache = null
 
   paneItemIsValid: (paneItem) ->
-    return false unless paneItem?
-    # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
-    return paneItem.getText?
+    if typeof atom.workspace.isTextEditor is "function"
+      atom.workspace.isTextEditor(paneItem)
+    else
+      return false unless paneItem?
+      # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
+      paneItem.getText?
 
   handleEvents: =>
     # Track the current pane item, update current editor

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -92,6 +92,7 @@ class AutocompleteManager
       @isCurrentFileBlackListedCache = null
 
   paneItemIsValid: (paneItem) ->
+    # TODO: remove conditional when `isTextEditor` is shipped.
     if typeof atom.workspace.isTextEditor is "function"
       atom.workspace.isTextEditor(paneItem)
     else

--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -55,9 +55,12 @@ class FuzzyProvider
     @buildWordList()
 
   paneItemIsValid: (paneItem) ->
-    return false unless paneItem?
-    # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
-    return paneItem.getText?
+    if typeof atom.workspace.isTextEditor is "function"
+      atom.workspace.isTextEditor(paneItem)
+    else
+      return false unless paneItem?
+      # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
+      paneItem.getText?
 
   # Public:  Gets called when the document has been changed. Returns an array
   # with suggestions. If `exclusive` is set to true and this method returns

--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -55,6 +55,7 @@ class FuzzyProvider
     @buildWordList()
 
   paneItemIsValid: (paneItem) ->
+    # TODO: remove conditional when `isTextEditor` is shipped.
     if typeof atom.workspace.isTextEditor is "function"
       atom.workspace.isTextEditor(paneItem)
     else

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -162,6 +162,7 @@ class SymbolProvider
   uniqueFilter: (completion) -> completion.text
 
   paneItemIsValid: (paneItem) ->
+    # TODO: remove conditional when `isTextEditor` is shipped.
     if typeof atom.workspace.isTextEditor is "function"
       atom.workspace.isTextEditor(paneItem)
     else

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -162,9 +162,12 @@ class SymbolProvider
   uniqueFilter: (completion) -> completion.text
 
   paneItemIsValid: (paneItem) ->
-    return false unless paneItem?
-    # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
-    return paneItem.getText?
+    if typeof atom.workspace.isTextEditor is "function"
+      atom.workspace.isTextEditor(paneItem)
+    else
+      return false unless paneItem?
+      # Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
+      paneItem.getText?
 
   ###
   Section: Suggesting Completions


### PR DESCRIPTION
We've introduced a new function to understand whether an object is a `TextEditor` or not in https://github.com/atom/atom/pull/9711.

This PR makes use of it to fix #614.

/cc: @benogle @atom/feedback 