### PR TITLE
Suffix replacement blacklist

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -106,6 +106,7 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => @autoConfirmSingleSuggestionEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffix', (value) => @consumeSuffix = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.suffixConsumeBlacklist', (value) => @suffixConsumeBlacklist = new Set(value)))
     @subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', (value) => @useAlternateScoring = value ))
     @subscriptions.add atom.config.observe 'autocomplete-plus.fileBlacklist', (value) =>
       @fileBlacklist = value?.map((s) -> s.trim())
@@ -392,8 +393,12 @@ class AutocompleteManager
     suffix = (suggestion.snippet ? suggestion.text)
     endPosition = [bufferPosition.row, bufferPosition.column + suffix.length]
     endOfLineText = editor.getTextInBufferRange([bufferPosition, endPosition])
+    isLegalSuffix = (suffix) =>
+      suffixConsumeBlacklist = suggestion.provider.suffixConsumeBlacklist ? @suffixConsumeBlacklist
+      hasBlacklistedCharacters = suffix.split('').some((c) => suffixConsumeBlacklist.has(c))
+      endOfLineText.startsWith(suffix) and not hasBlacklistedCharacters
     while suffix
-      return suffix if endOfLineText.startsWith(suffix)
+      return suffix if isLegalSuffix(suffix)
       suffix = suffix.slice(1)
     ''
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -118,16 +118,24 @@ module.exports =
       type: 'boolean'
       default: true
       order: 18
+    suffixConsumeBlacklist:
+      title: 'Blacklist for suffix consumption'
+      description: 'If the above box is checked, do not consume suffixes containing these characters. Should be a comma-separated list of single characters'
+      type: 'array'
+      default: [')']
+      items:
+        type: 'string'
+      order: 19
     useAlternateScoring:
       description: "Prefers runs of consecutive characters, acronyms and start of words. (Experimental)"
       type: 'boolean'
       default: false
-      order: 19
+      order: 20
     useLocalityBonus:
       description: "Gives words near the cursor position a higher score than those far away"
       type: 'boolean'
       default: true
-      order: 20
+      order: 21
 
   autocompleteManager: null
   subscriptions: null


### PR DESCRIPTION
Create a suffix replacement blacklist to prevent certain characters from being
consumed when the suffix of a suggestion is replaced. The setting defaults to
')'. The setting can be overridden by providers.

Closes #621