### PR TITLE
Explain how to use mulitple file blacklist items

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,7 +36,7 @@ module.exports =
       order: 5
     fileBlacklist:
       title: 'File Blacklist'
-      description: 'Suggestions will not be provided for files matching this list, e.g. *.md for Markdown files.'
+      description: 'Suggestions will not be provided for files matching this list, e.g. *.md for Markdown files. To blacklist more than one file extension, use comma as a separator, e.g. *.md, *.txt (both Markdown and text files).'
       type: 'array'
       default: ['.*']
       items:


### PR DESCRIPTION
While working with `autocomplete-plus` I tried to blacklist both `*.md` and `*.txt` but I failed to do so, because I was expecting that ` ` (space) would be a valid separator. Explaining a bit more what the _File Blacklist_ option expects would have saved me some time...