### PR TITLE
Don't overwrite non-word characters that match replacement suffixes

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -396,10 +396,11 @@ class AutocompleteManager
     suffix = (suggestion.snippet ? suggestion.text)
     endPosition = [bufferPosition.row, bufferPosition.column + suffix.length]
     endOfLineText = editor.getTextInBufferRange([bufferPosition, endPosition])
+    nonWordCharacters = new Set(atom.config.get('editor.nonWordCharacters').split(''))
     while suffix
-      return suffix if endOfLineText.startsWith(suffix)
+      break if endOfLineText.startsWith(suffix) and not nonWordCharacters.has(suffix[0])
       suffix = suffix.slice(1)
-    ''
+    suffix
 
   # Private: Checks whether the current file is blacklisted.
   #


### PR DESCRIPTION
This avoids overwriting characters in `editor.nonWordCharacters` when they follow the cursor and match a suffix of the autocomplete text.

This mainly comes up when the replacement text is a function call ending with `)`. Currently, when a `)` *already* follows the cursor, it gets overwritten by the autocomplete text, which is usually not what the user wants.

Refs https://github.com/atom/autocomplete-plus/pull/628

/cc @benogle @nmote 