### PR TITLE
Stop flickering when adjusting margins

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -252,11 +252,9 @@ class SuggestionListElement extends HTMLElement
     @uiProps.itemHeight ?= @selectedLi.offsetHeight
     @uiProps.paddingHeight ?= (parseInt(getComputedStyle(this)['padding-top']) + parseInt(getComputedStyle(this)['padding-bottom'])) ? 0
 
-    if atom.views.documentReadInProgress?
-      # Run in atom >= 0.193. Will batch write updates and run them immediately after this read
-      atom.views.updateDocument @updateUIForChangedProps.bind(this)
-    else
-      @updateUIForChangedProps()
+    # Update UI during this read, so that when polling the document the latest
+    # changes can be picked up.
+    @updateUIForChangedProps()
 
   updateUIForChangedProps: ->
     @scroller.style['max-height'] = "#{@maxVisibleSuggestions * @uiProps.itemHeight + @uiProps.paddingHeight}px"


### PR DESCRIPTION
See https://github.com/atom/atom/issues/8295#issuecomment-165112901 for more information about why this happens.

With this PR we prevent margins to be adjusted across two different animation frames, which causes the autocompletion box to flicker.

/cc: @benogle for :eyes: 