### PR TITLE
use fuzzaldrin-plus by default

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,7 +121,7 @@ module.exports =
     useAlternateScoring:
       description: "Prefers runs of consecutive characters, acronyms and start of words. (Experimental)"
       type: 'boolean'
-      default: false
+      default: true
       order: 19
     useLocalityBonus:
       description: "Gives words near the cursor position a higher score than those far away"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "atom-slick": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
-    "fuzzaldrin-plus": "^0.3.1",
+    "fuzzaldrin-plus": "^0.1.0",
     "grim": "^1.4.0",
     "minimatch": "^2.0.1",
     "selector-kit": "^0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "atom-slick": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
-    "fuzzaldrin-plus": "^0.1.0",
+    "fuzzaldrin-plus": "^0.3.1",
     "grim": "^1.4.0",
     "minimatch": "^2.0.1",
     "selector-kit": "^0.1",

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -192,8 +192,8 @@ describe 'Provider API', ->
 
         runs ->
           expect(getSuggestions()).toEqual [
-            {text: 'hai'}
             {text: '::cats'}
+            {text: 'hai'}
             {text: 'something'}
           ]
 

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -182,7 +182,7 @@ describe 'Provider API', ->
               {text: 'hai'}
               {text: 'okwow', replacementPrefix: 'k'}
               {text: 'ok', replacementPrefix: 'nope'}
-              {text: '::cats', replacementPrefix: '::'}
+              {text: '::cats', replacementPrefix: '::c'}
               {text: 'something', replacementPrefix: 'sm'}
             ]
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -297,8 +297,8 @@ describe 'SymbolProvider', ->
   describe "when the autocomplete.symbols changes between scopes", ->
     beforeEach ->
       editor.setText '''
-        // in0a0comment
-        invar = "in0a0string"
+        // in-a-comment
+        inVar = "in-a-string"
       '''
 
       commentConfig =
@@ -317,7 +317,7 @@ describe 'SymbolProvider', ->
       editor.setCursorBufferPosition([0, 2])
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
       expect(suggestions).toHaveLength 1
-      expect(suggestions[0].text).toBe 'in0a0comment'
+      expect(suggestions[0].text).toBe 'in-a-comment'
       expect(suggestions[0].type).toBe 'incomment'
 
       # Using the string config
@@ -325,7 +325,7 @@ describe 'SymbolProvider', ->
       editor.insertText(' ')
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
       expect(suggestions).toHaveLength 1
-      expect(suggestions[0].text).toBe 'in0a0string'
+      expect(suggestions[0].text).toBe 'in-a-string'
       expect(suggestions[0].type).toBe 'instring'
 
       # Using the default config
@@ -333,7 +333,7 @@ describe 'SymbolProvider', ->
       editor.insertText(' ')
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
       expect(suggestions).toHaveLength 3
-      expect(suggestions[0].text).toBe 'invar'
+      expect(suggestions[0].text).toBe 'inVar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
 
   describe "when the config contains a list of suggestion strings", ->

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -297,8 +297,8 @@ describe 'SymbolProvider', ->
   describe "when the autocomplete.symbols changes between scopes", ->
     beforeEach ->
       editor.setText '''
-        // in-a-comment
-        invar = "in-a-string"
+        // in0a0comment
+        invar = "in0a0string"
       '''
 
       commentConfig =
@@ -317,7 +317,7 @@ describe 'SymbolProvider', ->
       editor.setCursorBufferPosition([0, 2])
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
       expect(suggestions).toHaveLength 1
-      expect(suggestions[0].text).toBe 'in-a-comment'
+      expect(suggestions[0].text).toBe 'in0a0comment'
       expect(suggestions[0].type).toBe 'incomment'
 
       # Using the string config
@@ -325,7 +325,7 @@ describe 'SymbolProvider', ->
       editor.insertText(' ')
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
       expect(suggestions).toHaveLength 1
-      expect(suggestions[0].text).toBe 'in-a-string'
+      expect(suggestions[0].text).toBe 'in0a0string'
       expect(suggestions[0].type).toBe 'instring'
 
       # Using the default config


### PR DESCRIPTION
For some reason the request to update ac+ got translated to command palette.
Probably not bad but this still need to be done.

@benogle @nathansobo 