### PR TITLE
upgrade to latest ci scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: objective-c
-
 notifications:
   email:
     on_success: never
@@ -19,3 +17,25 @@ git:
 branches:
   only:
     - master
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,18 @@
 version: "{build}"
-
 os: Windows Server 2012 R2
 
+test: off
+deploy: off
+
+init:
+  - cmd: rd /s /q %CHOCOLATEYINSTALL%
+  - ps: iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
 install:
-  - choco install atom -y
+  - cinst atom -y
   - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm clean"
   - "%LOCALAPPDATA%/atom/bin/apm install"
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
-
-test: off
-
-deploy: off


### PR DESCRIPTION
The latest scripts from: https://github.com/atom/ci

What's new:
- linux support
- building on `beta` and on `stable` (on osx and linux)
- build on Travis container based version
