### PR TITLE
Batch autocompletion show/hide

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -456,7 +456,7 @@ class AutocompleteManager
   bufferSaved: =>
     @hideSuggestionList() unless @autosaveEnabled
 
-  bufferChangedText: (changes) =>
+  bufferChangedText: ({changes}) =>
     lastCursorPosition = @editor.getLastCursor().getBufferPosition()
     changeOccurredNearLastCursor = changes.some ({start, newExtent}) ->
       newRange = new Range(start, start.traverse(newExtent))

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -443,6 +443,12 @@ class AutocompleteManager
   #
   # data - An {Object} containing information on why the cursor has been moved
   cursorMoved: ({textChanged}) =>
+    # The delay is a workaround for the backspace case. The way atom implements
+    # backspace is to select left 1 char, then delete. This results in a
+    # cursorMoved event with textChanged == false. So we delay, and if the
+    # bufferChanged handler decides to show suggestions, it will cancel the
+    # hideSuggestionList request. If there is no bufferChanged event,
+    # suggestionList will be hidden.
     @requestHideSuggestionList() if not textChanged and not @shouldActivate
 
   # Private: Gets called when the user saves the document. Cancels the

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -459,7 +459,6 @@ class AutocompleteManager
   bufferChangedText: (changes) =>
     lastCursorPosition = @editor.getLastCursor().getBufferPosition()
     changeOccurredNearLastCursor = changes.some ({start, newExtent}) ->
-      start = Point.fromObject(start)
       newRange = new Range(start, start.traverse(newExtent))
       newRange.containsPoint(lastCursorPosition)
 

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -449,7 +449,7 @@ class AutocompleteManager
     # bufferChanged handler decides to show suggestions, it will cancel the
     # hideSuggestionList request. If there is no bufferChanged event,
     # suggestionList will be hidden.
-    @requestHideSuggestionList() if not textChanged and not @shouldActivate
+    @requestHideSuggestionList() unless textChanged or @shouldActivate
 
   # Private: Gets called when the user saves the document. Cancels the
   # autocompletion.


### PR DESCRIPTION
Depends on atom/text-buffer#127.

Before:

![screen shot 2016-01-28 at 13 16 56](https://cloud.githubusercontent.com/assets/482957/12644194/72002dd8-c5c1-11e5-89d9-4417c31a77ab.png)

After:

![screen shot 2016-01-28 at 13 19 21](https://cloud.githubusercontent.com/assets/482957/12644241/d43e8f08-c5c1-11e5-9945-8862e2f6b60b.png)
![screen shot 2016-01-28 at 13 19 40](https://cloud.githubusercontent.com/assets/482957/12644242/d444bce8-c5c1-11e5-94fa-a2ff9cecfd5a.png)

It now takes `~2ms` instead of `~585ms`. :racehorse: :chart_with_upwards_trend: 

@benogle: I'd :heart: to have your feedback on this. It seems like a 100% backwards-compatible and behavior-preserving change, but some more pair of :eyes: on this would be awesome. :pray: 

/cc: @nathansobo @maxbrunsfeld @kuychaco 