### PR TITLE
Fix lint warning in symbol-provider.coffee

### DIFF
--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -243,7 +243,7 @@ class SymbolProvider
   getLocalityScore: (bufferPosition, bufferRowsContainingSymbol) ->
     if bufferRowsContainingSymbol?
       rowDifference = Number.MAX_VALUE
-      rowDifference = Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol
+      rowDifference = (Math.min(rowDifference, bufferRow - bufferPosition.row) for bufferRow in bufferRowsContainingSymbol)
       locality = @computeLocalityModifier(rowDifference)
       locality
     else


### PR DESCRIPTION
Fix travis-ci message
```
  ⚡ lib/symbol-provider.coffee
     ⚡ #246: Comprehensions must have parentheses around them.
```