### PR TITLE
Alternate completion keybinding behaviour

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -69,6 +69,7 @@ class SuggestionListElement extends HTMLElement
     @subscriptions.add @model.onDidSelectTop(@moveSelectionToTop.bind(this))
     @subscriptions.add @model.onDidSelectBottom(@moveSelectionToBottom.bind(this))
     @subscriptions.add @model.onDidConfirmSelection(@confirmSelection.bind(this))
+    @subscriptions.add @model.onDidConfirmSelectionIf(@confirmSelectionIf.bind(this))
     @subscriptions.add @model.onDidDispose(@dispose.bind(this))
 
     @subscriptions.add atom.config.observe 'autocomplete-plus.suggestionListFollows', (@suggestionListFollows) =>
@@ -120,6 +121,7 @@ class SuggestionListElement extends HTMLElement
       @returnItemsToPool(0)
 
   render: ->
+    @nonDefaultIndex = false
     @selectedIndex = 0
     atom.views.pollAfterNextUpdate?()
     atom.views.updateDocument @renderItems.bind(this)
@@ -163,6 +165,7 @@ class SuggestionListElement extends HTMLElement
     @setSelectedIndex(newIndex) if @selectedIndex isnt newIndex
 
   setSelectedIndex: (index) ->
+    @nonDefaultIndex = true
     @selectedIndex = index
     atom.views.updateDocument @renderSelectedItem.bind(this)
 
@@ -184,6 +187,12 @@ class SuggestionListElement extends HTMLElement
       @model.confirm(item)
     else
       @model.cancel()
+
+  confirmSelectionIf: (event) ->
+    if @nonDefaultIndex
+      @confirmSelection()
+    else
+      event.abortKeyBinding()
 
   renderList: ->
     @innerHTML = ListTemplate

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -69,7 +69,7 @@ class SuggestionListElement extends HTMLElement
     @subscriptions.add @model.onDidSelectTop(@moveSelectionToTop.bind(this))
     @subscriptions.add @model.onDidSelectBottom(@moveSelectionToBottom.bind(this))
     @subscriptions.add @model.onDidConfirmSelection(@confirmSelection.bind(this))
-    @subscriptions.add @model.onDidConfirmSelectionIf(@confirmSelectionIf.bind(this))
+    @subscriptions.add @model.onDidconfirmSelectionIfNonDefault(@confirmSelectionIfNonDefault.bind(this))
     @subscriptions.add @model.onDidDispose(@dispose.bind(this))
 
     @subscriptions.add atom.config.observe 'autocomplete-plus.suggestionListFollows', (@suggestionListFollows) =>
@@ -188,10 +188,14 @@ class SuggestionListElement extends HTMLElement
     else
       @model.cancel()
 
-  confirmSelectionIf: (event) ->
+  # Private: Confirms the currently selected item only if it is not the default
+  # item or cancels the view if none has been selected.
+  confirmSelectionIfNonDefault: (event) ->
+    return unless @model.isActive()
     if @nonDefaultIndex
       @confirmSelection()
     else
+      @model.cancel()
       event.abortKeyBinding()
 
   renderList: ->

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -10,7 +10,7 @@ class SuggestionList
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-text-editor.autocomplete-active',
       'autocomplete-plus:confirm': @confirmSelection,
-      'autocomplete-plus:confirmIf': @confirmSelectionIf,
+      'autocomplete-plus:confirmIf': @confirmSelectionIfNonDefault,
       'autocomplete-plus:cancel': @cancel
     @subscriptions.add atom.config.observe 'autocomplete-plus.useCoreMovementCommands', => @bindToMovementCommands()
 
@@ -51,7 +51,7 @@ class SuggestionList
   addKeyboardInteraction: ->
     @removeKeyboardInteraction()
     completionKey = atom.config.get('autocomplete-plus.confirmCompletion') or ''
-    
+
     keys = {}
     keys['tab'] = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
     if completionKey.indexOf('enter') > -1
@@ -81,8 +81,8 @@ class SuggestionList
   confirmSelection: =>
     @emitter.emit('did-confirm-selection')
 
-  confirmSelectionIf: (event) =>
-    @emitter.emit('did-confirm-selection-if', event)
+  confirmSelectionIfNonDefault: (event) =>
+    @emitter.emit('did-confirm-selection-if-non-default', event)
 
   selectNext: ->
     @emitter.emit('did-select-next')
@@ -109,8 +109,8 @@ class SuggestionList
   onDidConfirmSelection: (fn) ->
     @emitter.on('did-confirm-selection', fn)
 
-  onDidConfirmSelectionIf: (fn) ->
-    @emitter.on('did-confirm-selection-if', fn)
+  onDidconfirmSelectionIfNonDefault: (fn) ->
+    @emitter.on('did-confirm-selection-if-non-default', fn)
 
   onDidConfirm: (fn) ->
     @emitter.on('did-confirm', fn)

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -53,7 +53,7 @@ class SuggestionList
     completionKey = atom.config.get('autocomplete-plus.confirmCompletion') or ''
 
     keys = {}
-    keys['tab']   = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
+    keys['tab'] = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
     if completionKey.indexOf('enter') > -1
       if completionKey.indexOf('always') > -1
         keys['enter'] = 'autocomplete-plus:confirmIfNonDefault'

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -10,7 +10,7 @@ class SuggestionList
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-text-editor.autocomplete-active',
       'autocomplete-plus:confirm': @confirmSelection,
-      'autocomplete-plus:confirmIf': @confirmSelectionIfNonDefault,
+      'autocomplete-plus:confirmIfNonDefault': @confirmSelectionIfNonDefault,
       'autocomplete-plus:cancel': @cancel
     @subscriptions.add atom.config.observe 'autocomplete-plus.useCoreMovementCommands', => @bindToMovementCommands()
 
@@ -53,10 +53,10 @@ class SuggestionList
     completionKey = atom.config.get('autocomplete-plus.confirmCompletion') or ''
 
     keys = {}
-    keys['tab'] = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
+    keys['tab']   = 'autocomplete-plus:confirm' if completionKey.indexOf('tab') > -1
     if completionKey.indexOf('enter') > -1
-      if atom.config.get('autocomplete-plus.alternateCompletion')
-        keys['enter'] = 'autocomplete-plus:confirmIf'
+      if completionKey.indexOf('always') > -1
+        keys['enter'] = 'autocomplete-plus:confirmIfNonDefault'
       else
         keys['enter'] = 'autocomplete-plus:confirm'
 

--- a/package.json
+++ b/package.json
@@ -69,16 +69,10 @@
       "enum": [
         "tab",
         "enter",
-        "tab and enter"
+        "tab and enter",
+        "tab always, enter when suggestion explicitly selected"
       ],
       "order": 4
-    },
-    "alternateCompletion": {
-      "title": "Alternate Completion Keybindings",
-      "description": "If this setting is true, enter will only confirm the selected suggestion if it has been changed by the user (e.g. by using the movement keys).",
-      "type": "boolean",
-      "default": false,
-      "order": 4.5
     },
     "useCoreMovementCommands": {
       "title": "Use Core Movement Commands",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,13 @@
       ],
       "order": 4
     },
+    "alternateCompletion": {
+      "title": "Alternate Completion Keybindings",
+      "description": "If this setting is true, enter will only confirm the selection if it has been changed by the user.",
+      "type": "boolean",
+      "default": false,
+      "order": 4.5
+    },
     "useCoreMovementCommands": {
       "title": "Use Core Movement Commands",
       "description": "Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/atom/autocomplete-plus#remapping-movement-commands",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "alternateCompletion": {
       "title": "Alternate Completion Keybindings",
-      "description": "If this setting is true, enter will only confirm the selection if it has been changed by the user.",
+      "description": "If this setting is true, enter will only confirm the selected suggestion if it has been changed by the user (e.g. by using the movement keys).",
       "type": "boolean",
       "default": false,
       "order": 4.5

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1077,6 +1077,48 @@ describe 'Autocomplete Manager', ->
 
             expect(editor.getText()).toBe 'ok then a.someMethod()'
 
+      describe "when the alternate keyboard integration is used", ->
+        beforeEach ->
+          atom.config.set('autocomplete-plus.confirmCompletion', 'tab and enter')
+          atom.config.set('autocomplete-plus.alternateCompletion', true)
+
+        it 'inserts the word on tab and moves the cursor to the end of the word', ->
+          triggerAutocompletion(editor, false, 'a')
+
+          runs ->
+            key = atom.keymaps.constructor.buildKeydownEvent('tab', {target: document.activeElement})
+            atom.keymaps.handleKeyboardEvent(key)
+
+            expect(editor.getText()).toBe 'ok then ab'
+
+            bufferPosition = editor.getCursorBufferPosition()
+            expect(bufferPosition.row).toEqual(0)
+            expect(bufferPosition.column).toEqual(10)
+
+        it 'does not insert the word on enter', ->
+          triggerAutocompletion(editor, false, 'a')
+
+          runs ->
+            key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
+            atom.keymaps.handleKeyboardEvent(key)
+            expect(editor.getText()).toBe 'ok then a\n'
+
+        it 'inserts the word on enter after the selection has been changed and moves the cursor to the end of the word', ->
+          triggerAutocompletion(editor, false, 'a')
+
+          runs ->
+            editorView = atom.views.getView(editor)
+            atom.commands.dispatch(editorView, 'core:move-down')
+            key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
+            atom.keymaps.handleKeyboardEvent(key)
+
+            expect(editor.getText()).toBe 'ok then abc'
+
+            bufferPosition = editor.getCursorBufferPosition()
+            expect(bufferPosition.row).toEqual(0)
+            expect(bufferPosition.column).toEqual(11)
+
+
       describe 'when tab is used to accept suggestions', ->
         beforeEach ->
           atom.config.set('autocomplete-plus.confirmCompletion', 'tab')

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1079,8 +1079,7 @@ describe 'Autocomplete Manager', ->
 
       describe "when the alternate keyboard integration is used", ->
         beforeEach ->
-          atom.config.set('autocomplete-plus.confirmCompletion', 'tab and enter')
-          atom.config.set('autocomplete-plus.alternateCompletion', true)
+          atom.config.set('autocomplete-plus.confirmCompletion', 'tab always, enter when suggestion explicitly selected')
 
         it 'inserts the word on tab and moves the cursor to the end of the word', ->
           triggerAutocompletion(editor, false, 'a')


### PR DESCRIPTION
This introduces a new setting which will enable alternate behaviour for `Enter` when the suggestion list is opened:
- If the default suggestion is selected, `Enter` will pass through and insert a linebreak. `Tab` will still insert that suggestion.
- If the selected suggestion has been changed by some means, e.g. `Cursor down`, `Enter` will insert that suggestion, just like `Tab`.

I'm totally open to suggestions regarding method names and the setting description. Also, I don't have much experience with the specs, but I *think* they should test what I want them to. :)