### PR TITLE
Observe the TextEditorRegistry, constrained by a CSS selector.

### DIFF
--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -14,7 +14,7 @@ class FuzzyProvider
   editor: null
   buffer: null
 
-  selector: '*'
+  scopeSelector: '*'
   inclusionPriority: 0
   suggestionPriority: 0
 

--- a/lib/provider-metadata.coffee
+++ b/lib/provider-metadata.coffee
@@ -1,21 +1,51 @@
 {Selector} = require 'selector-kit'
 {selectorForScopeChain, selectorsMatchScopeChain} = require './scope-helpers'
 
+# Deferred requires
+grim = null
+
 module.exports =
 class ProviderMetadata
   constructor: (@provider, @apiVersion) ->
-    @selectors = Selector.create(@provider.selector)
-    @disableForSelectors = Selector.create(@provider.disableForSelector) if @provider.disableForSelector?
+    if @provider.selector?
+      grim ?= require 'grim'
+      grim.deprecate """
+        Autocomplete provider '#{@provider.constructor.name}(#{@provider.id})'
+        specifies `selector` instead of the `scopeSelector` attribute.
+        See https://github.com/atom/autocomplete-plus/wiki/Provider-API.
+      """
+      @scopeSelectors = Selector.create(@provider.selector)
+    else
+      @scopeSelectors = Selector.create(@provider.scopeSelector)
+
+    if @provider.disableForSelector?
+      grim ?= require 'grim'
+      grim.deprecate """
+        Autocomplete provider '#{@provider.constructor.name}(#{@provider.id})'
+        specifies `disableForSelector` instead of the `disableForScopeSelector`
+        attribute.
+        See https://github.com/atom/autocomplete-plus/wiki/Provider-API.
+      """
+      @disableForScopeSelectors = Selector.create(@provider.disableForSelector)
+    else if @provider.disableForScopeSelector?
+      @disableForScopeSelectors = Selector.create(@provider.disableForScopeSelector)
 
     # TODO API: remove this when 1.0 is pulled out
     if providerBlacklist = @provider.providerblacklist?['autocomplete-plus-fuzzyprovider']
       @disableDefaultProviderSelectors = Selector.create(providerBlacklist)
 
-  matchesScopeChain: (scopeChain) ->
-    if @disableForSelectors?
-      return false if selectorsMatchScopeChain(@disableForSelectors, scopeChain)
+  matchesEditor: (editor) ->
+    if @provider.getTextEditorSelector?
+      atom.views.getView(editor).matches(@provider.getTextEditorSelector())
+    else
+      # Backwards compatibility.
+      atom.views.getView(editor).matches('atom-pane > .item-views > atom-text-editor')
 
-    if selectorsMatchScopeChain(@selectors, scopeChain)
+  matchesScopeChain: (scopeChain) ->
+    if @disableForScopeSelectors?
+      return false if selectorsMatchScopeChain(@disableForScopeSelectors, scopeChain)
+
+    if selectorsMatchScopeChain(@scopeSelectors, scopeChain)
       true
     else
       false
@@ -27,7 +57,7 @@ class ProviderMetadata
       false
 
   getSpecificity: (scopeChain) ->
-    if selector = selectorForScopeChain(@selectors, scopeChain)
+    if selector = selectorForScopeChain(@scopeSelectors, scopeChain)
       selector.getSpecificity()
     else
       0

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -1,7 +1,7 @@
 # This provider is currently experimental.
 
 _ = require 'underscore-plus'
-{TextBuffer, Range, CompositeDisposable}  = require 'atom'
+{TextBuffer, Range, CompositeDisposable, Disposable}  = require 'atom'
 {Selector} = require 'selector-kit'
 {UnicodeLetters} = require './unicode-helpers'
 SymbolStore = require './symbol-store'
@@ -19,7 +19,8 @@ class SymbolProvider
   buffer: null
   changeUpdateDelay: 300
 
-  selector: '*'
+  textEditorSelectors: new Set(['atom-pane > .item-views > atom-text-editor'])
+  scopeSelector: '*'
   inclusionPriority: 0
   suggestionPriority: 0
 
@@ -66,6 +67,13 @@ class SymbolProvider
 
   dispose: =>
     @subscriptions.dispose()
+
+  addTextEditorSelector: (selector) ->
+    @textEditorSelectors.add(selector)
+    new Disposable => @textEditorSelectors.delete(selector)
+
+  getTextEditorSelector: ->
+    Array.from(@textEditorSelectors).join(', ')
 
   watchEditor: (editor) =>
     buffer = editor.getBuffer()

--- a/spec/provider-api-legacy-spec.coffee
+++ b/spec/provider-api-legacy-spec.coffee
@@ -131,7 +131,7 @@ describe 'Provider API Legacy', ->
 
   describe 'Provider API v1.1.0', ->
     it 'registers the provider specified by {providers: [provider]}', ->
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
 
       testProvider =
         selector: '.source.js,.source.coffee'
@@ -139,7 +139,7 @@ describe 'Provider API Legacy', ->
 
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.1.0', {providers: [testProvider]})
 
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
 
   describe 'Provider API v1.0.0', ->
     [registration1, registration2, registration3] = []
@@ -170,10 +170,10 @@ describe 'Provider API Legacy', ->
 
     it 'should allow registration of a provider', ->
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider =
         requestHandler: (options) ->
@@ -189,13 +189,13 @@ describe 'Provider API Legacy', ->
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       triggerAutocompletion(editor, true, 'o')
 
@@ -207,10 +207,10 @@ describe 'Provider API Legacy', ->
 
     it 'should dispose a provider registration correctly', ->
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider =
         requestHandler: (options) ->
@@ -223,36 +223,36 @@ describe 'Provider API Legacy', ->
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
     it 'should remove a providers registration if the provider is disposed', ->
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider =
         requestHandler: (options) ->
@@ -267,18 +267,18 @@ describe 'Provider API Legacy', ->
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -41,18 +41,18 @@ describe 'Provider API', ->
         selector: '.source.js,.source.coffee'
         getSuggestions: (options) -> [text: 'ohai', replacementPrefix: 'ohai']
 
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', [testProvider])
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
 
     it 'registers the provider specified by the naked provider', ->
       testProvider =
         selector: '.source.js,.source.coffee'
         getSuggestions: (options) -> [text: 'ohai', replacementPrefix: 'ohai']
 
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
-      expect(autocompleteManager.providerManager.providersForScopeDescriptor('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
 
     it 'passes the correct parameters to getSuggestions for the version', ->
       testProvider =


### PR DESCRIPTION
Currently, only `TextEditors` that are items of `Panes` are observed.
With atom/atom#10851, observing all `TextEditors` will be supported, which the `autocomplete-manager` will use with this PR.

To then provide autocompletion in various `TextEditors` (e.g. in `find-and-replace`), a `Provider` should be able to specify to which `TextEditor` it applies.
This PR implements that by allowing the `Provider` to specify a CSS selector for the `TextEditorElement` to which it should apply.
The default will be set to `atom-pane > .item-views > atom-text-editor` for backwards compatibility.

This will support the use case mentioned in #383.

/cc @benogle 