### PR TITLE
Fix type of seen suggestions

### DIFF
--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -50,6 +50,21 @@ export default class SymbolStore {
     let firstLetter = prefix[0].toLowerCase()
     let symbolsByWord = new Map()
     let wordOccurrences = new Map()
+    let seen = new Map()
+    
+    let suggestions = []
+    for (let type of Object.keys(config)) {
+      let symbols = config[type].suggestions || EMPTY_ARRAY
+      for (let symbol of symbols) {
+        let {score} = this.scoreSymbol(prefix, symbol, cursorBufferRow, Number.MAX_VALUE)
+        if (score > 0) {
+          symbol.replacementPrefix = prefix
+          suggestions.push({symbol, score})
+          seen.set((symbol.text ? symbol.text : "") + (symbol.snippet ? symbol.snippet : ""), true)
+        }
+      }
+    }
+
     for (let bufferLines of this.linesForBuffers(buffers)) {
       let symbolBufferRow = 0
       for (let lineSymbolsByLetter of bufferLines) {
@@ -71,25 +86,15 @@ export default class SymbolStore {
               let type = symbol.matchingTypeForConfig(config)
               if (type != null) {
                 symbol = {text: symbol.text, type, replacementPrefix: prefix}
-                symbolsByWord.set(symbol.text, {symbol, score, localityScore})
+                if (!seen.get(symbol.text)) {
+                  symbolsByWord.set(symbol.text, {symbol, score, localityScore})
+                }
               }
             }
           }
         }
 
         symbolBufferRow++
-      }
-    }
-
-    let suggestions = []
-    for (let type of Object.keys(config)) {
-      let symbols = config[type].suggestions || EMPTY_ARRAY
-      for (let symbol of symbols) {
-        let {score} = this.scoreSymbol(prefix, symbol, cursorBufferRow, Number.MAX_VALUE)
-        if (score > 0) {
-          symbol.replacementPrefix = prefix
-          suggestions.push({symbol, score})
-        }
       }
     }
 

--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -50,8 +50,8 @@ export default class SymbolStore {
     let firstLetter = prefix[0].toLowerCase()
     let symbolsByWord = new Map()
     let wordOccurrences = new Map()
-    let seen = new Map()
-    
+    let builtinSymbolsByWord = new Set()
+
     let suggestions = []
     for (let type of Object.keys(config)) {
       let symbols = config[type].suggestions || EMPTY_ARRAY
@@ -60,7 +60,11 @@ export default class SymbolStore {
         if (score > 0) {
           symbol.replacementPrefix = prefix
           suggestions.push({symbol, score})
-          seen.set((symbol.text ? symbol.text : "") + (symbol.snippet ? symbol.snippet : ""), true)
+          if (symbol.text) {
+            builtinSymbolsByWord.add(symbol.text)
+          } else if (symbol.snippet) {
+            builtinSymbolsByWord.add(symbol.snippet)
+          }
         }
       }
     }
@@ -86,7 +90,7 @@ export default class SymbolStore {
               let type = symbol.matchingTypeForConfig(config)
               if (type != null) {
                 symbol = {text: symbol.text, type, replacementPrefix: prefix}
-                if (!seen.get(symbol.text)) {
+                if (!builtinSymbolsByWord.has(symbol.text)) {
                   symbolsByWord.set(symbol.text, {symbol, score, localityScore})
                 }
               }

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -100,7 +100,7 @@ describe 'SymbolStore', ->
       expect(occurrences[0].symbol.text).toBe 'abc'
       expect(occurrences[0].symbol.type).toBe 'newtype'
 
-    it "dont override description of built-in function", ->
+    it "doesn't override built-in suggestions with the symbols found in the buffer", ->
       config =
         function:
           selectors: Selector.create('.function')

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -100,6 +100,29 @@ describe 'SymbolStore', ->
       expect(occurrences[0].symbol.text).toBe 'abc'
       expect(occurrences[0].symbol.type).toBe 'newtype'
 
+    it "dont override description of built-in function", ->
+      config =
+        function:
+          selectors: Selector.create('.function')
+          typePriority: 1
+        builtins:
+          suggestions: [
+            {
+              'type': 'function'
+              'rightLabel': 'global function'
+              'text': 'ValueFromFile'
+              'description': 'Test description.'
+            }]
+
+      editor.moveToBottom()
+      editor.insertText('ValueFromFile()')
+
+      occurrences = store.symbolsForConfig(config, [editor.getBuffer()], 'value')
+      expect(occurrences.length).toBe 1
+      expect(occurrences[0].symbol.text).toBe 'ValueFromFile'
+      expect(occurrences[0].symbol.description).toBe 'Test description.'
+      expect(occurrences[0].symbol.rightLabel).toBe 'global function'
+
   describe "when there are multiple files with tokens in the store", ->
     [config, editor1, editor2] = []
     beforeEach ->


### PR DESCRIPTION
Given
* you set some completions in settings.cson in  'autocomplete' -> 'symbols' -> 'builtins' -> 'suggestions' section ([example](https://github.com/xDrivenDevelopment/atom-language-1c-bsl/blob/master/settings/language-1c-bsl.cson#L21))

---

When
* you type this function first time

Then
* you'll see a `b` mark and a description
![1](https://cloud.githubusercontent.com/assets/1132840/13319604/d894aaf6-dbd3-11e5-89a1-e13beb51f747.PNG)

When
* you type this function *not* first time

Then
* you'll see no mark or description
![2](https://cloud.githubusercontent.com/assets/1132840/13319666/54575bf2-dbd4-11e5-9e43-1d060ae355d6.PNG)

---

With this PR:
![3](https://cloud.githubusercontent.com/assets/1132840/13319691/86e23452-dbd4-11e5-9e23-a498a7bbc573.PNG)