### PR TITLE
Fix maximum call stack size exceeded error

### DIFF
--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -5,6 +5,7 @@ const EMPTY_ARRAY = []
 import {selectorsMatchScopeChain, buildScopeChainString} from './scope-helpers'
 import fuzzaldrin from 'fuzzaldrin'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
+import {spliceWithArray} from 'underscore-plus'
 
 class Symbol {
   constructor (text, scopes) {
@@ -117,7 +118,8 @@ export default class SymbolStore {
       newLines.push(symbolsByLetter)
     }
 
-    this.linesForBuffer(editor.getBuffer()).splice(start.row, oldExtent.row + 1, ...newLines)
+    let bufferLines = this.linesForBuffer(editor.getBuffer())
+    spliceWithArray(bufferLines, start.row, oldExtent.row + 1, newLines)
   }
 
   linesForBuffers (buffers) {


### PR DESCRIPTION
Closes #679. I believe that was caused by the stack growing because of `Array.prototype.splice` that requires the `...` operator, hence making the parameter list humongous.

/cc: @benogle 