### PR TITLE
Avoid deprecations introduced in atom/ns-use-display-layers branch

### DIFF
--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -70,7 +70,11 @@ class SymbolProvider
   watchEditor: (editor) =>
     buffer = editor.getBuffer()
     editorSubscriptions = new CompositeDisposable
-    editorSubscriptions.add editor.displayBuffer.onDidTokenize =>
+
+    # TODO: Remove this conditional once atom/ns-use-display-layers reaches stable and editor.onDidTokenize is always available
+    onDidTokenizeProvider = if editor.onDidTokenize? then editor else editor.displayBuffer
+
+    editorSubscriptions.add onDidTokenizeProvider.onDidTokenize =>
       @buildWordListOnNextTick(editor)
     editorSubscriptions.add editor.onDidDestroy =>
       index = @getWatchedEditorIndex(editor)

--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -99,8 +99,11 @@ export default class SymbolStore {
   recomputeSymbolsForEditorInBufferRange (editor, start, oldExtent, newExtent) {
     let newEnd = start.row + newExtent.row
     let newLines = []
+    // TODO: Remove this conditional once atom/ns-use-display-layers reaches stable and editor.tokenizedBuffer is available
+    let tokenizedBuffer = editor.tokenizedBuffer ? editor.tokenizedBuffer : editor.displayBuffer.tokenizedBuffer
+
     for (var bufferRow = start.row; bufferRow <= newEnd; bufferRow++) {
-      let tokenizedLine = editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow)
+      let tokenizedLine = tokenizedBuffer.tokenizedLineForRow(bufferRow)
       if (tokenizedLine == null) continue
 
       let symbolsByLetter = new Map


### PR DESCRIPTION
We still use a private API, `TokenizedBuffer.prototype.tokenizedLineForRow` but we avoid accessing the `TextEditor.prototype.displayBuffer` property in versions of Atom where doing so triggers a deprecation warning. This is a backward compatible change.