### PR TITLE
Add 3.0 service endpoint which exposes `textEditorSelector`

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -56,12 +56,12 @@ module.exports =
   consumeProvider_2_0: (providers) ->
     @consumeProvider(providers, '2.0.0')
 
-  # 2.1.0 API
+  # 3.0.0 API
   # providers - either a provider or a list of providers
-  consumeProvider_2_1: (providers) ->
-    @consumeProvider(providers, '2.1.0')
+  consumeProvider_3_0: (providers) ->
+    @consumeProvider(providers, '3.0.0')
 
-  consumeProvider: (providers, apiVersion='2.1.0') ->
+  consumeProvider: (providers, apiVersion='3.0.0') ->
     providers = [providers] if providers? and not Array.isArray(providers)
     return unless providers?.length > 0
     registrations = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,19 +41,20 @@ module.exports =
   # 1.0.0 API
   # service - {provider: provider1}
   consumeProvider_1_0: (service) ->
-    # TODO API: Deprecate, tell them to upgrade to 2.1
+    # TODO API: Deprecate, tell them to upgrade to 3.0
     return unless service?.provider?
     @consumeProvider([service.provider], '1.0.0')
 
   # 1.1.0 API
   # service - {providers: [provider1, provider2, ...]}
   consumeProvider_1_1: (service) ->
-    # TODO API: Deprecate, tell them to upgrade to 2.1
+    # TODO API: Deprecate, tell them to upgrade to 3.0
     @consumeProvider(service?.providers, '1.1.0')
 
   # 2.0.0 API
   # providers - either a provider or a list of providers
   consumeProvider_2_0: (providers) ->
+    # TODO API: Deprecate, tell them to upgrade to 3.0
     @consumeProvider(providers, '2.0.0')
 
   # 3.0.0 API

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,20 +40,28 @@ module.exports =
 
   # 1.0.0 API
   # service - {provider: provider1}
-  consumeProviderLegacy: (service) ->
-    # TODO API: Deprecate, tell them to upgrade to 2.0
+  consumeProvider_1_0: (service) ->
+    # TODO API: Deprecate, tell them to upgrade to 2.1
     return unless service?.provider?
     @consumeProvider([service.provider], '1.0.0')
 
   # 1.1.0 API
   # service - {providers: [provider1, provider2, ...]}
-  consumeProvidersLegacy: (service) ->
-    # TODO API: Deprecate, tell them to upgrade to 2.0
+  consumeProvider_1_1: (service) ->
+    # TODO API: Deprecate, tell them to upgrade to 2.1
     @consumeProvider(service?.providers, '1.1.0')
 
   # 2.0.0 API
   # providers - either a provider or a list of providers
-  consumeProvider: (providers, apiVersion='2.0.0') ->
+  consumeProvider_2_0: (providers) ->
+    @consumeProvider(providers, '2.0.0')
+
+  # 2.1.0 API
+  # providers - either a provider or a list of providers
+  consumeProvider_2_1: (providers) ->
+    @consumeProvider(providers, '2.1.0')
+
+  consumeProvider: (providers, apiVersion='2.1.0') ->
     providers = [providers] if providers? and not Array.isArray(providers)
     return unless providers?.length > 0
     registrations = new CompositeDisposable

--- a/lib/private-symbols.coffee
+++ b/lib/private-symbols.coffee
@@ -1,0 +1,1 @@
+exports.API_VERSION = Symbol('Private property: Semantic version of the service endpoint.')

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -135,7 +135,7 @@ class ProviderManager
   isProviderRegistered: (provider) ->
     @metadataForProvider(provider)?
 
-  addProvider: (provider, apiVersion='2.0.0') =>
+  addProvider: (provider, apiVersion='3.0.0') =>
     return if @isProviderRegistered(provider)
     ProviderMetadata ?= require './provider-metadata'
     @providers.push new ProviderMetadata(provider, apiVersion)
@@ -149,13 +149,13 @@ class ProviderManager
         break
     @subscriptions?.remove(provider) if provider.dispose?
 
-  registerProvider: (provider, apiVersion='2.0.0') =>
+  registerProvider: (provider, apiVersion='3.0.0') =>
     return unless provider?
 
     provider[API_VERSION] = apiVersion
 
     apiIs2_0 = semver.satisfies(apiVersion, '>=2.0.0')
-    apiIs2_1 = semver.satisfies(apiVersion, '>=2.1.0')
+    apiIs3_0 = semver.satisfies(apiVersion, '>=3.0.0')
 
     if apiIs2_0
       if provider.id? and provider isnt @defaultProvider
@@ -183,23 +183,21 @@ class ProviderManager
           See https://github.com/atom/autocomplete-plus/wiki/Provider-API
         """
 
-    if apiIs2_1
+    if apiIs3_0
       if provider.selector?
-        grim ?= require 'grim'
-        grim.deprecate """
+        throw new Error("""
           Autocomplete provider '#{provider.constructor.name}(#{provider.id})'
           specifies `selector` instead of the `scopeSelector` attribute.
           See https://github.com/atom/autocomplete-plus/wiki/Provider-API.
-        """
+        """)
 
       if provider.disableForSelector?
-        grim ?= require 'grim'
-        grim.deprecate """
+        throw new Error("""
           Autocomplete provider '#{provider.constructor.name}(#{provider.id})'
           specifies `disableForSelector` instead of the `disableForScopeSelector`
           attribute.
           See https://github.com/atom/autocomplete-plus/wiki/Provider-API.
-        """
+        """)
 
     unless @isValidProvider(provider, apiVersion)
       console.warn "Provider #{provider.constructor.name} is not valid", provider

--- a/lib/provider-metadata.coffee
+++ b/lib/provider-metadata.coffee
@@ -26,7 +26,7 @@ class ProviderMetadata
     if providerBlacklist = @provider.providerblacklist?['autocomplete-plus-fuzzyprovider']
       @disableDefaultProviderSelectors = Selector.create(providerBlacklist)
 
-    @enableCustomTextEditorSelector = semver.satisfies(@provider[API_VERSION], '>=2.1.0')
+    @enableCustomTextEditorSelector = semver.satisfies(@provider[API_VERSION], '>=3.0.0')
 
   matchesEditor: (editor) ->
     if @enableCustomTextEditorSelector and @provider.getTextEditorSelector?

--- a/lib/provider-metadata.coffee
+++ b/lib/provider-metadata.coffee
@@ -26,10 +26,10 @@ class ProviderMetadata
     if providerBlacklist = @provider.providerblacklist?['autocomplete-plus-fuzzyprovider']
       @disableDefaultProviderSelectors = Selector.create(providerBlacklist)
 
-    @enableCustorTextEditorSelector = semver.satisfies(@provider[API_VERSION], '>=2.1.0')
+    @enableCustomTextEditorSelector = semver.satisfies(@provider[API_VERSION], '>=2.1.0')
 
   matchesEditor: (editor) ->
-    if @enableCustorTextEditorSelector and @provider.getTextEditorSelector?
+    if @enableCustomTextEditorSelector and @provider.getTextEditorSelector?
       atom.views.getView(editor).matches(@provider.getTextEditorSelector())
     else
       # Backwards compatibility.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-slick": "^2.0.0",
-    "fuzzaldrin": "^3.0.0",
+    "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.1.0",
     "grim": "^1.4.0",
     "minimatch": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-slick": "^2.0.0",
-    "fuzzaldrin": "^2.1.0",
+    "fuzzaldrin": "^3.0.0",
     "fuzzaldrin-plus": "^0.1.0",
     "grim": "^1.4.0",
     "minimatch": "^2.0.1",
@@ -30,7 +30,7 @@
         "1.0.0": "consumeProvider_1_0",
         "1.1.0": "consumeProvider_1_1",
         "2.0.0": "consumeProvider_2_0",
-        "2.1.0": "consumeProvider_2_1"
+        "3.0.0": "consumeProvider_3_0"
       }
     },
     "snippets": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "consumedServices": {
     "autocomplete.provider": {
       "versions": {
-        "1.0.0": "consumeProviderLegacy",
-        "1.1.0": "consumeProvidersLegacy",
-        "2.0.0": "consumeProvider"
+        "1.0.0": "consumeProvider_1_0",
+        "1.1.0": "consumeProvider_1_1",
+        "2.0.0": "consumeProvider_2_0",
+        "2.1.0": "consumeProvider_2_1"
       }
     },
     "snippets": {

--- a/spec/provider-api-legacy-spec.coffee
+++ b/spec/provider-api-legacy-spec.coffee
@@ -47,6 +47,22 @@ describe 'Provider API Legacy', ->
     testProvider?.dispose() if testProvider?.dispose?
     testProvider = null
 
+  describe "Provider with API v2.0 registered as 3.0", ->
+    it "throws exceptions for renamed provider properties on registration", ->
+      expect(->
+        mainModule.consumeProvider_3_0({
+          selector: '*'
+          getSuggestions: ->
+        })
+      ).toThrow()
+
+      expect(->
+        mainModule.consumeProvider_3_0({
+          disableForSelector: '*'
+          getSuggestions: ->
+        })
+      ).toThrow()
+
   describe 'Provider with API v1.0 registered as 2.0', ->
     it "raises deprecations for provider attributes on registration", ->
       numberDeprecations = grim.getDeprecationsLength()

--- a/spec/provider-manager-spec.coffee
+++ b/spec/provider-manager-spec.coffee
@@ -51,10 +51,10 @@ describe 'Provider Manager', ->
       expect(providerManager.isProviderRegistered(testProvider)).toEqual(false)
       expect(hasDisposable(providerManager.subscriptions, testProvider)).toBe false
 
-      providerManager.addProvider(testProvider, '2.0.0')
+      providerManager.addProvider(testProvider, '3.0.0')
       expect(providerManager.isProviderRegistered(testProvider)).toEqual(true)
       apiVersion = providerManager.apiVersionForProvider(testProvider)
-      expect(apiVersion).toEqual('2.0.0')
+      expect(apiVersion).toEqual('3.0.0')
       expect(hasDisposable(providerManager.subscriptions, testProvider)).toBe true
 
     it 'removes providers', ->
@@ -74,41 +74,41 @@ describe 'Provider Manager', ->
         badgetSuggestions: (options) ->
         scopeSelector: '.source.js'
         dispose: ->
-      expect(providerManager.isValidProvider({}, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(bogusProvider, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '2.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider({}, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
     it 'can identify a provider with an invalid getSuggestions', ->
       bogusProvider =
         getSuggestions: 'yo, this is a bad handler'
         scopeSelector: '.source.js'
         dispose: ->
-      expect(providerManager.isValidProvider({}, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(bogusProvider, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '2.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider({}, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
     it 'can identify a provider with a missing scope selector', ->
       bogusProvider =
         getSuggestions: (options) ->
         aSelector: '.source.js'
         dispose: ->
-      expect(providerManager.isValidProvider(bogusProvider, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '2.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
     it 'can identify a provider with an invalid scope selector', ->
       bogusProvider =
         getSuggestions: (options) ->
         scopeSelector: ''
         dispose: ->
-      expect(providerManager.isValidProvider(bogusProvider, '2.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '2.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
       bogusProvider =
         getSuggestions: (options) ->
         scopeSelector: false
         dispose: ->
 
-      expect(providerManager.isValidProvider(bogusProvider, '2.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
 
     it 'correctly identifies a 1.0 provider', ->
       bogusProvider =
@@ -197,7 +197,7 @@ describe 'Provider Manager', ->
         dispose: ->
           return
 
-      expect(providerManager.isValidProvider(testProvider, '2.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
       expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
       expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)


### PR DESCRIPTION
@as-cii, @wvanlint I decided we should only show deprecation warnings when someone is trying to use the new feature and there is ambiguity. So this adds a 2.1 service endpoint. To get the text editor selector you have to use it. If you use it you'll get deprecation warnings with the old field names. Still need to update documentation.