### PR TITLE
Add keymap to navigate to descriptionMoreURL with keyboard shortcut

### DIFF
--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -3,4 +3,4 @@
 
 'atom-text-editor.autocomplete-active':
   'escape': 'autocomplete-plus:cancel'
-  'f1': 'autocomplete-plus:navigate-to-more-url'
+  'f1': 'autocomplete-plus:navigate-to-description-more-link'

--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -3,3 +3,4 @@
 
 'atom-text-editor.autocomplete-active':
   'escape': 'autocomplete-plus:cancel'
+  'f1': 'autocomplete-plus:navigate-to-more-url'

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -156,9 +156,10 @@ class AutocompleteManager
         @findSuggestions(event.detail?.activatedManually ? true)
 
       'autocomplete-plus:navigate-to-more-url': =>
-        moreLinkElement = @editorView.querySelector('.suggestion-description-more-link')
-        moreLinkURL = moreLinkElement.href
-        require('shell').openExternal(moreLinkURL)
+        descriptionContainer = @editorView.querySelector('.suggestion-description')
+        if descriptionContainer.style.display is 'block'
+          descriptionMoreLink = @editorView.querySelector('.suggestion-description-more-link')
+          require('shell').openExternal(descriptionMoreLink.href)
 
   # Private: Finds suggestions for the current prefix, sets the list items,
   # positions the overlay and shows it

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -155,6 +155,11 @@ class AutocompleteManager
         @shouldDisplaySuggestions = true
         @findSuggestions(event.detail?.activatedManually ? true)
 
+      'autocomplete-plus:navigate-to-more-url': =>
+        moreLinkElement = @editorView.querySelector('.suggestion-description-more-link')
+        moreLinkURL = moreLinkElement.href
+        require('shell').openExternal(moreLinkURL)
+
   # Private: Finds suggestions for the current prefix, sets the list items,
   # positions the overlay and shows it
   findSuggestions: (activatedManually) =>

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -155,12 +155,13 @@ class AutocompleteManager
         @shouldDisplaySuggestions = true
         @findSuggestions(event.detail?.activatedManually ? true)
 
-      'autocomplete-plus:navigate-to-more-url': =>
-        descriptionContainer = @editorView.querySelector('.suggestion-description')
+      'autocomplete-plus:navigate-to-description-more-link': =>
+        suggestionList = atom.views.getView(@suggestionList)
+        descriptionContainer = suggestionList.querySelector('.suggestion-description')
         if descriptionContainer.style.display is 'block'
-          descriptionMoreLink = @editorView.querySelector('.suggestion-description-more-link')
+          descriptionMoreLink = descriptionContainer.querySelector('.suggestion-description-more-link')
           require('shell').openExternal(descriptionMoreLink.href)
-
+          
   # Private: Finds suggestions for the current prefix, sets the list items,
   # positions the overlay and shows it
   findSuggestions: (activatedManually) =>

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -680,6 +680,29 @@ describe 'Autocomplete Manager', ->
             expect(newWidth).toBeGreaterThan 0
             expect(newWidth).toBeLessThan listWidth
 
+        it "opens the suggestion description url in an external browser", ->
+          spyOn(provider, 'getSuggestions').andCallFake ->
+              list =[
+                {text: 'ab',    description: 'ab yeah ok',   descriptionMoreURL: 'https://github.com'}
+                {text: 'abc',   description: 'abc yeah ok',  descriptionMoreURL: 'https://atom.io'}
+                {text: 'abcd',  description: 'abcd yeah ok', descriptionMoreURL: 'https://github.com/atom/atom'}
+              ]
+          shell = require 'shell'
+          spyOn(shell, 'openExternal')
+
+          triggerAutocompletion(editor, true, 'a')
+
+          runs ->
+            atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
+            expect(shell.openExternal).toHaveBeenCalled()
+            expect(shell.openExternal.argsForCall[0][0]).toBe "https://github.com/"
+            shell.openExternal.reset()
+
+            atom.commands.dispatch(editorView, 'core:move-down')
+            atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
+            expect(shell.openExternal).toHaveBeenCalled()
+            expect(shell.openExternal.argsForCall[0][0]).toBe "https://atom.io/"
+
     describe "when useCoreMovementCommands is toggled", ->
       [suggestionList] = []
 


### PR DESCRIPTION
Fixes #567

I added a command so that if a descriptionMoreURL is present in the suggestion list, the user can use the keyboard to open the appropriate external link. Currently I have it set up as f1 like the issue suggests (and you actually have to hit the function key before f1 for it to work right). However, I'll let y'all decide on the best shortcut if this is implemented.

I added a spec that is currently passing.  For some reason a forward slash is being added to the end of my test urls (https://github.com and https://atom.io specifically) when being called by `shell.openExternal` in my spec and I'm not sure why or if it's even an issue.  Let me know if it is. 

And tell me if I need to fix/change other stuffs.

@benogle 
