### PR TITLE
Fixes #728 - Use table-cell display for right label

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -8,8 +8,8 @@ ItemTemplate = """
   <span class="left-label"></span>
   <span class="word-container">
     <span class="word"></span>
-    <span class="right-label"></span>
   </span>
+  <span class="right-label"></span>
 """
 
 ListTemplate = """

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -26,7 +26,6 @@ autocomplete-suggestion-list.select-list.popover-list {
 
   .suggestion-list-scroller {
     overflow-y: auto;
-    margin-right: 10px;
   }
 
   .suggestion-description {
@@ -139,21 +138,22 @@ autocomplete-suggestion-list {
     color: @text-color-subtle;
 
     &:empty {
-      padding: 0;
+      padding-right: 0;
     }
   }
 
   .right-label {
-    padding-left: @item-padding;
-    padding-right: @item-side-padding;
-
+    padding-right: @item-padding;
     font-size: @font-size-small;
     color: @text-color-subtle;
 
     &:empty {
-      width: @item-side-padding;
-      padding: 0;
+      padding-right: 0;
     }
+  }
+
+  .word-container {
+    padding-right: @item-padding;
   }
 
   .word {
@@ -185,7 +185,7 @@ autocomplete-suggestion-list {
   }
 
   .word {
-    max-width: 500px;
+    max-width: 430px; // magic number to also fit the icon-container + scrollbar in the 800px max-width
   }
 
   .make-type-icon(attribute, @syntax-color-attribute);

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -26,6 +26,7 @@ autocomplete-suggestion-list.select-list.popover-list {
 
   .suggestion-list-scroller {
     overflow-y: auto;
+    margin-right: 10px;
   }
 
   .suggestion-description {
@@ -143,7 +144,6 @@ autocomplete-suggestion-list {
   }
 
   .right-label {
-    float: right;
     padding-left: @item-padding;
     padding-right: @item-side-padding;
 

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -59,6 +59,7 @@ autocomplete-suggestion-list.select-list.popover-list {
     margin-top: 0;
     display: table;
     width: 100%;
+    margin-right: 10px; // Needed to prevent horizontal scrolling when right label is too long
 
     li {
       display: table-row;


### PR DESCRIPTION
Fixes [#728](https://github.com/atom/autocomplete-plus/issues/728)

This PR includes a simple change to move the right-label span up one level so that it will be displayed as a `table-cell` instead of using `float: right`. This fixes layout problems by ensuring that the right label always has enough space reserved to avoid lines shifting down.

Before change:

![right-label-bad-layout](https://cloud.githubusercontent.com/assets/978214/15903025/fcb518d6-2d67-11e6-956e-4d8d3b36aac2.png)

After change:

![right-label-good-layout](https://cloud.githubusercontent.com/assets/978214/15903048/1449b45c-2d68-11e6-93d2-bb275c9bd65e.png)

After change, with a really long suggestion:

![right-label-good-layout-long](https://cloud.githubusercontent.com/assets/978214/15903075/2ae5d772-2d68-11e6-8f91-d916dd4f8188.png)



