### PR TITLE
URL updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Atom contributing guide](https://atom.io/docs/latest/contributing)
+See the [Atom contributing guide](https://github.com/atom/flight-manual.atom.io/blob/master/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Atom contributing guide](https://github.com/atom/flight-manual.atom.io/blob/master/CONTRIBUTING.md)
+See the [Atom contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     },
     "scopeBlacklist": {
       "title": "Scope Blacklist",
-      "description": "Suggestions will not be provided for scopes matching this list. See: https://atom.io/docs/latest/behind-atom-scoped-settings-scopes-and-scope-descriptors",
+      "description": "Suggestions will not be provided for scopes matching this list. See: http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/",
       "type": "array",
       "default": [],
       "items": {


### PR DESCRIPTION
Two tiny fixes for dead URLs:

1. URL for scopes displayed within settings
2. URL for Atom Contributing Guidelines