### PR TITLE
Guard against undefined path

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -441,7 +441,7 @@ class AutocompleteManager
       return @isCurrentFileBlackListedCache
 
     minimatch ?= require('minimatch')
-    fileName = path.basename(@buffer.getPath())
+    fileName = path.basename(@buffer.getPath() ? '')
     for blacklistGlob in @fileBlacklist
       if minimatch(fileName, blacklistGlob)
         @isCurrentFileBlackListedCache = true


### PR DESCRIPTION
Passing in `undefined` to `path` module functions results is no longer supported as of Node v6. This PR is part of the effort to upgrade Atom to run on the latest release of Electron (atom/atom#12300).