### PR TITLE
Fix shadow DOM removal deprecations

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -117,16 +117,12 @@ class AutocompleteManager
   handleEvents: =>
     # Observe `TextEditors` in the `TextEditorRegistry` and listen for focus,
     # or observe active `Pane` items respectively.
-    # TODO: remove conditional when `TextEditorRegistry` is shipped.
-    if atom.textEditors?
-      @subscriptions.add(atom.textEditors.observe (editor) =>
-        view = atom.views.getView(editor)
-        if view is document.activeElement
-          @updateCurrentEditor(editor)
-        view.addEventListener 'focus', (element) =>
-          @updateCurrentEditor(editor))
-    else
-      @subscriptions.add(atom.workspace.observeActivePaneItem(@updateCurrentEditor))
+    @subscriptions.add(atom.textEditors.observe (editor) =>
+      view = atom.views.getView(editor)
+      if view is document.activeElement.closest('atom-text-editor')
+        @updateCurrentEditor(editor)
+      view.addEventListener 'focus', (element) =>
+        @updateCurrentEditor(editor))
 
     # Watch config values
     @subscriptions.add(atom.config.observe('autosave.enabled', (value) => @autosaveEnabled = value))

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1994,7 +1994,7 @@ describe 'Autocomplete Manager', ->
     editorView.component?.overlayManager?
 
   pixelLeftForBufferPosition = (bufferPosition) ->
-    gutterWidth ?= editorView.shadowRoot.querySelector('.gutter').offsetWidth
+    gutterWidth ?= editorView.querySelector('.gutter').offsetWidth
     left = editorView.pixelPositionForBufferPosition(bufferPosition).left
     left += editorView.offsetLeft
     left = gutterWidth + left if requiresGutter()

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1994,7 +1994,8 @@ describe 'Autocomplete Manager', ->
     editorView.component?.overlayManager?
 
   pixelLeftForBufferPosition = (bufferPosition) ->
-    gutterWidth ?= editorView.querySelector('.gutter').offsetWidth
+    gutter = editorView.querySelector('.gutter') ? editorView.shadowRoot.querySelector('.gutter')
+    gutterWidth ?= gutter.offsetWidth
     left = editorView.pixelPositionForBufferPosition(bufferPosition).left
     left += editorView.offsetLeft
     left = gutterWidth + left if requiresGutter()

--- a/spec/provider-api-legacy-spec.coffee
+++ b/spec/provider-api-legacy-spec.coffee
@@ -9,26 +9,19 @@ describe 'Provider API Legacy', ->
   [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider] = []
 
   beforeEach ->
-    runs ->
-      deprecations = []
-      spyOn(grim, 'deprecate').andCallFake (message) ->
-        deprecations.push new MockDeprecation(message)
-      spyOn(grim, 'getDeprecationsLength').andCallFake ->
-        deprecations.length
-      spyOn(grim, 'getDeprecations').andCallFake ->
-        deprecations
+    jasmine.snapshotDeprecations()
 
-      # Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      atom.config.set('editor.fontSize', '16')
+    # Set to live completion
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    atom.config.set('editor.fontSize', '16')
 
-      # Set the completion delay
-      completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-      completionDelay += 100 # Rendering
+    # Set the completion delay
+    completionDelay = 100
+    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
+    completionDelay += 100 # Rendering
 
-      workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
     waitsForPromise ->
       Promise.all [
@@ -46,6 +39,7 @@ describe 'Provider API Legacy', ->
     registration = null
     testProvider?.dispose() if testProvider?.dispose?
     testProvider = null
+    jasmine.restoreDeprecationsSnapshot()
 
   describe "Provider with API v2.0 registered as 3.0", ->
     it "throws exceptions for renamed provider properties on registration", ->


### PR DESCRIPTION
This pull request fixes two deprecations that will be added as part of the shadow DOM removal:

1. Instead of relying on `document.activeElement` returning an `atom-text-editor` element, it now uses the `closest` API instead. 
2. It replaces usages of `TextEditorElement.prototype.shadowRoot` with the editor element itself.

/cc: @atom/core 