### PR TITLE
Don't recompute symbols or fuzzy provider tokens when `editor.largeFileMode` is on

### DIFF
--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -56,10 +56,11 @@ class FuzzyProvider
 
     # Subscribe to buffer events:
     @currentEditorSubscriptions = new CompositeDisposable
-    @currentEditorSubscriptions.add @buffer.onDidSave(@bufferSaved)
-    @currentEditorSubscriptions.add @buffer.onWillChange(@bufferWillChange)
-    @currentEditorSubscriptions.add @buffer.onDidChange(@bufferDidChange)
-    @buildWordList()
+    unless @editor.largeFileMode
+      @currentEditorSubscriptions.add @buffer.onDidSave(@bufferSaved)
+      @currentEditorSubscriptions.add @buffer.onWillChange(@bufferWillChange)
+      @currentEditorSubscriptions.add @buffer.onDidChange(@bufferDidChange)
+      @buildWordList()
 
   paneItemIsValid: (paneItem) ->
     # TODO: remove conditional when `isTextEditor` is shipped.

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -130,6 +130,27 @@ describe 'SymbolProvider', ->
       advanceClock 1 # build the new wordlist
       expect(suggestionsForPrefix(provider, coffeeEditor, 'item')).toHaveLength 0
 
+  describe "when `editor.largeFileMode` is true", ->
+    it "doesn't recompute symbols when the buffer changes", ->
+      coffeeEditor = null
+
+      waitsForPromise ->
+        atom.packages.activatePackage("language-coffee-script")
+
+      waitsForPromise ->
+        atom.workspace.open('sample.coffee').then (e) ->
+          coffeeEditor = e
+          coffeeEditor.largeFileMode = true
+
+      runs ->
+        waitForBufferToStopChanging()
+        coffeeEditor.setCursorBufferPosition([2, 0])
+        expect(suggestionsForPrefix(provider, coffeeEditor, 'Some')).toEqual([])
+
+        coffeeEditor.getBuffer().setTextInRange([[0, 0], [0, 0]], 'abc')
+        waitForBufferToStopChanging()
+        expect(suggestionsForPrefix(provider, coffeeEditor, 'abc')).toEqual([])
+
   describe "when autocomplete-plus.minimumWordLength is > 1", ->
     beforeEach ->
       atom.config.set('autocomplete-plus.minimumWordLength', 3)


### PR DESCRIPTION
After an editor has been created and its lines tokenized, we were previously scanning the entire buffer to search for symbols or fuzzy provider tokens. This operation could be quite expensive, and its cost grew linearly with the size of the file. 

![screen shot 2016-10-12 at 10 13 27](https://cloud.githubusercontent.com/assets/482957/19302623/210d3bea-9065-11e6-8846-0304b7b10b98.png)

![screen shot 2016-10-12 at 10 13 51](https://cloud.githubusercontent.com/assets/482957/19302634/33b94414-9065-11e6-89e8-bf5a9ffe863a.png)

*(Benchmark performed by opening [big.txt](https://github.com/atom/autocomplete-plus/files/523872/big.txt), 5.2MB)*

With this pull request, when `largeFileMode` is detected, we simply avoid scanning the buffer, which makes opening files larger than 2MB significantly faster. In the future, we might also improve this further for files smaller than 2MB by recomputing symbols or fuzzy provider tokens in chunks via request idle callbacks.

For now, in conjunction with https://github.com/atom/atom/pull/12933, this should fix all the remaining large files performance bottlenecks that don't concern [text-buffer](https://github.com/atom/text-buffer). 

/cc: @atom/core 