### PR TITLE
Add descriptionMarkdown option to specify markdown in desriptions

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -52,7 +52,7 @@ export default class AutocompleteManager {
 
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableExtendedUnicodeSupport', enableExtendedUnicodeSupport => {
       if (enableExtendedUnicodeSupport) {
-        this.prefixRegex = new RegExp(`(['\"~\`!@#\\$%^&*\\(\\)\\{\\}\\[\\]=\+,/\\?>])?(([${UnicodeLetters}\\d_]+[${UnicodeLetters}\\d_-]*)|([.:;[{(< ]+))$`)
+        this.prefixRegex = new RegExp(`(['"~\`!@#\\$%^&*\\(\\)\\{\\}\\[\\]=+,/\\?>])?(([${UnicodeLetters}\\d_]+[${UnicodeLetters}\\d_-]*)|([.:;[{(< ]+))$`)
         this.wordPrefixRegex = new RegExp(`^[${UnicodeLetters}\\d_]+[${UnicodeLetters}\\d_-]*$`)
       } else {
         this.prefixRegex = /(\b|['"~`!@#\$%^&*\(\)\{\}\[\]=\+,/\?>])((\w+[\w-]*)|([.:;[{(< ]+))$/

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -130,18 +130,18 @@ class SuggestionListElement extends HTMLElement {
 
     if (item.descriptionMarkdown && item.descriptionMarkdown.length > 0) {
       this.descriptionContainer.style.display = 'block'
-      this.descriptionContent.innerHTML = marked.parse(item.descriptionMarkdown, {sanitize: true});
-      this.setDescriptionMoreLink(item);
+      this.descriptionContent.innerHTML = marked.parse(item.descriptionMarkdown, {sanitize: true})
+      this.setDescriptionMoreLink(item)
     } else if (item.description && item.description.length > 0) {
       this.descriptionContainer.style.display = 'block'
       this.descriptionContent.textContent = item.description
-      this.setDescriptionMoreLink(item);
+      this.setDescriptionMoreLink(item)
     } else {
       this.descriptionContainer.style.display = 'none'
     }
   }
 
-  setDescriptionMoreLink(item) {
+  setDescriptionMoreLink (item) {
     if ((item.descriptionMoreURL != null) && (item.descriptionMoreURL.length != null)) {
       this.descriptionMoreLink.style.display = 'inline'
       this.descriptionMoreLink.setAttribute('href', item.descriptionMoreURL)
@@ -422,7 +422,7 @@ class SuggestionListElement extends HTMLElement {
 
     const sanitizedType = escapeHtml(isString(type) ? type : '')
     const sanitizedIconHTML = isString(iconHTML) ? iconHTML : undefined
-    const defaultLetterIconHTML = sanitizedType ? `<span class=\"icon-letter\">${sanitizedType[0]}</span>` : ''
+    const defaultLetterIconHTML = sanitizedType ? `<span class="icon-letter">${sanitizedType[0]}</span>` : ''
     const defaultIconHTML = DefaultSuggestionTypeIconHTML[sanitizedType] != null ? DefaultSuggestionTypeIconHTML[sanitizedType] : defaultLetterIconHTML
     if ((sanitizedIconHTML || defaultIconHTML) && iconHTML !== false) {
       typeIconContainer.innerHTML = IconTemplate

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -4,6 +4,7 @@ import { Disposable, CompositeDisposable } from 'atom'
 import SnippetParser from './snippet-parser'
 import { isString } from './type-helpers'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
+import marked from 'marked'
 
 const ItemTemplate = `<span class="icon-container"></span>
   <span class="left-label"></span>
@@ -127,18 +128,26 @@ class SuggestionListElement extends HTMLElement {
       return
     }
 
-    if (item.description && item.description.length > 0) {
+    if (item.descriptionMarkdown && item.descriptionMarkdown.length > 0) {
+      this.descriptionContainer.style.display = 'block'
+      this.descriptionContent.innerHTML = marked.parse(item.descriptionMarkdown, {sanitize: true});
+      this.setDescriptionMoreLink(item);
+    } else if (item.description && item.description.length > 0) {
       this.descriptionContainer.style.display = 'block'
       this.descriptionContent.textContent = item.description
-      if ((item.descriptionMoreURL != null) && (item.descriptionMoreURL.length != null)) {
-        this.descriptionMoreLink.style.display = 'inline'
-        this.descriptionMoreLink.setAttribute('href', item.descriptionMoreURL)
-      } else {
-        this.descriptionMoreLink.style.display = 'none'
-        this.descriptionMoreLink.setAttribute('href', '#')
-      }
+      this.setDescriptionMoreLink(item);
     } else {
       this.descriptionContainer.style.display = 'none'
+    }
+  }
+
+  setDescriptionMoreLink(item) {
+    if ((item.descriptionMoreURL != null) && (item.descriptionMoreURL.length != null)) {
+      this.descriptionMoreLink.style.display = 'inline'
+      this.descriptionMoreLink.setAttribute('href', item.descriptionMoreURL)
+    } else {
+      this.descriptionMoreLink.style.display = 'none'
+      this.descriptionMoreLink.setAttribute('href', '#')
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.1.0",
     "grim": "^1.4.0",
+    "marked": "^0.3.6",
     "minimatch": "^2.0.1",
     "selector-kit": "^0.1",
     "semver": "^4.3.3",

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -738,7 +738,6 @@ describe('Autocomplete Manager', () => {
         })
 
         it('parses markdown in the description', () => {
-          let listWidth = null
           spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
             let list = [
               {text: 'ab', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmmmmmm**'},
@@ -755,7 +754,7 @@ describe('Autocomplete Manager', () => {
             let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
             expect(suggestionList).toExist()
 
-            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmmmmmm');
+            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmmmmmm')
 
             editor.insertText('b')
             editor.insertText('c')
@@ -766,7 +765,7 @@ describe('Autocomplete Manager', () => {
             let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
             expect(suggestionList).toExist()
 
-            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmm');
+            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmm')
           })
         })
 

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -737,6 +737,39 @@ describe('Autocomplete Manager', () => {
           })
         })
 
+        it('parses markdown in the description', () => {
+          let listWidth = null
+          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
+            let list = [
+              {text: 'ab', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmmmmmm**'},
+              {text: 'abc', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmm**'},
+              {text: 'abcd', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmm**'},
+              {text: 'abcde', descriptionMarkdown: '**mmmmmmmmmmmmmm**'}
+            ]
+            return (list.filter((item) => item.text.startsWith(prefix)).map((item) => item))
+          })
+
+          triggerAutocompletion(editor, true, 'a')
+
+          runs(() => {
+            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            expect(suggestionList).toExist()
+
+            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmmmmmm');
+
+            editor.insertText('b')
+            editor.insertText('c')
+            waitForAutocomplete()
+          })
+
+          runs(() => {
+            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            expect(suggestionList).toExist()
+
+            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmm');
+          })
+        })
+
         it('adjusts the width when the description changes', () => {
           let listWidth = null
           spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {


### PR DESCRIPTION
This PR adds support for supplying markdown in descriptions of suggestions. It supersedes #733 which originally allowed HTML to be specified.

Fixes #423 
Fixes #626 
Closes #733