### PR TITLE
Add note to issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
 
-Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io. Anything that is "actionable" (ie, has a clear goal that can be fixed or implemented) can be created as an issue. Anything else (questions, feedback, complaints) belong on Slack or Discuss.
 
 -->
 


### PR DESCRIPTION
This adds a note (from https://github.com/atom/autocomplete-plus/issues/813#issuecomment-272645653) to the issue template, about what belongs as an issue. This should make it a bit clearer.
