### PR TITLE
Reduce default autoActivationDelay from 100ms to 0ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     },
     "autoActivationDelay": {
       "title": "Delay Before Suggestions Are Shown",
-      "description": "This prevents suggestions from being shown too frequently. Usually, the default works well. A lower value than the default has performance implications, and is not advised.",
+      "description": "If you are experiencing performance issues when typing, you should try increasing this value to a non-zero number (e.g. 100).",
       "type": "integer",
-      "default": 100,
+      "default": 0,
       "order": 2
     },
     "maxVisibleSuggestions": {


### PR DESCRIPTION
This PR lowers the default `autoActivationDelay` setting from 100ms to 0ms, which - for the vast majority of users - will have the effect of making autocomplete feel "snappier". This introduces the risk that an errant autocomplete provider could affect typing performance, if it is synchronous and locks up the thread. This risk is countered by the fact that the API is promise based, and if node's main thread locks up (promise or otherwise) then there is a bigger issue for which this timeout value will be irrelevant.

- In retrospect, this was premature optimization; the API is promise-based, and providers should not be doing synchronous work
- The net effect of setting the default autoActivationDelay to 100 is that users perceive the performance of autocomplete-plus to be less favorable than the behavior in other editors
- If a provider is designed well and can cache results / function in a performant way (e.g. in 5ms), it is penalized by the default autoActivationDelay disproportionately
- Retaining the delay means that there is still a debounce, and there is a guard to prevent multiple suggestion requests from being satisfied at once, avoiding unnecessary work

/cc @nmote 