### PR TITLE
Stop registering SuggestionListElement as a custom element

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -8,7 +8,6 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
 import ProviderManager from './provider-manager'
 import SuggestionList from './suggestion-list'
-import SuggestionListElement from './suggestion-list-element'
 import { UnicodeLetters } from './unicode-helpers'
 
 // Deferred requires

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -61,10 +61,6 @@ export default class AutocompleteManager {
     }
     ))
     this.subscriptions.add(this.providerManager)
-    this.subscriptions.add(atom.views.addViewProvider(SuggestionList, (model) => {
-      return new SuggestionListElement().initialize(model)
-    }))
-
     this.handleEvents()
     this.handleCommands()
     this.subscriptions.add(this.suggestionList) // We're adding this last so it is disposed after events

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,7 @@
-'use babel'
+const {CompositeDisposable} = require('atom')
+const AutocompleteManager = require('./autocomplete-manager')
 
-import { CompositeDisposable } from 'atom'
-
-export default {
+module.exports = {
   autocompleteManager: null,
   subscriptions: null,
 
@@ -38,7 +37,6 @@ export default {
 
   getAutocompleteManager () {
     if (!this.autocompleteManager) {
-      const AutocompleteManager = require('./autocomplete-manager')
       this.autocompleteManager = new AutocompleteManager()
       this.subscriptions.add(this.autocompleteManager)
     }

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -10,10 +10,10 @@ import { selectorsMatchScopeChain } from './scope-helpers'
 import { API_VERSION } from './private-symbols'
 
 // Deferred requires
-let SymbolProvider = null
-let FuzzyProvider = null
-let grim = null
-let ProviderMetadata = null
+let SymbolProvider = require('./symbol-provider')
+let FuzzyProvider = require('./fuzzy-provider')
+let grim = require('grim')
+let ProviderMetadata = require('./provider-metadata')
 
 export default class ProviderManager {
   constructor () {
@@ -128,10 +128,8 @@ export default class ProviderManager {
     if (enabled) {
       if ((this.defaultProvider != null) || (this.defaultProviderRegistration != null)) { return }
       if (atom.config.get('autocomplete-plus.defaultProvider') === 'Symbol') {
-        if (typeof SymbolProvider === 'undefined' || SymbolProvider === null) { SymbolProvider = require('./symbol-provider') }
         this.defaultProvider = new SymbolProvider()
       } else {
-        if (typeof FuzzyProvider === 'undefined' || FuzzyProvider === null) { FuzzyProvider = require('./fuzzy-provider') }
         this.defaultProvider = new FuzzyProvider()
       }
       this.defaultProviderRegistration = this.registerProvider(this.defaultProvider)
@@ -186,7 +184,6 @@ export default class ProviderManager {
 
   addProvider (provider, apiVersion = '3.0.0') {
     if (this.isProviderRegistered(provider)) { return }
-    if (typeof ProviderMetadata === 'undefined' || ProviderMetadata === null) { ProviderMetadata = require('./provider-metadata') }
     this.providers.push(new ProviderMetadata(provider, apiVersion))
     if (provider.dispose != null) { return this.subscriptions.add(provider) }
   }
@@ -217,7 +214,6 @@ export default class ProviderManager {
 
     if (apiIs200) {
       if ((provider.id != null) && provider !== this.defaultProvider) {
-        if (typeof grim === 'undefined' || grim === null) { grim = require('grim') }
         grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
 contains an \`id\` property.
 An \`id\` attribute on your provider is no longer necessary.

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -49,8 +49,6 @@ class SuggestionListElement extends HTMLElement {
   }
 
   attachedCallback () {
-    // TODO: Fix overlay decorator to in atom to apply class attribute correctly, then move this to overlay creation point.
-    this.parentElement.classList.add('autocomplete-plus')
     this.addActiveClassToEditor()
     if (!this.ol) { this.renderList() }
     return this.itemsChanged()

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -49,15 +49,8 @@ class SuggestionListElement extends HTMLElement {
   }
 
   attachedCallback () {
-    this.addActiveClassToEditor()
     if (!this.ol) { this.renderList() }
     return this.itemsChanged()
-  }
-
-  detachedCallback () {
-    if (this.activeClassDisposable && this.activeClassDisposable.dispose) {
-      this.activeClassDisposable.dispose()
-    }
   }
 
   initialize (model) {
@@ -164,23 +157,6 @@ class SuggestionListElement extends HTMLElement {
 
     atom.views.updateDocument(this.renderItems.bind(this))
     return atom.views.readDocument(this.readUIPropsFromDOM.bind(this))
-  }
-
-  addActiveClassToEditor () {
-    let activeEditor
-    if (this.model) {
-      activeEditor = this.model.activeEditor
-    }
-    const editorElement = atom.views.getView(activeEditor)
-    if (editorElement && editorElement.classList) {
-      editorElement.classList.add('autocomplete-active')
-    }
-
-    this.activeClassDisposable = new Disposable(() => {
-      if (editorElement && editorElement.classList) {
-        editorElement.classList.remove('autocomplete-active')
-      }
-    })
   }
 
   moveSelectionUp () {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -1,4 +1,4 @@
-const {Disposable, CompositeDisposable} = require('atom')
+const {CompositeDisposable} = require('atom')
 const SnippetParser = require('./snippet-parser')
 const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -54,8 +54,8 @@ class SuggestionListElement extends HTMLElement {
     this.descriptionMoreLink = this.querySelector('.suggestion-description-more-link')
   }
 
-  attachedCallback () {
-    return this.itemsChanged()
+  didAttach () {
+    this.itemsChanged()
   }
 
   initialize (model) {
@@ -161,7 +161,7 @@ class SuggestionListElement extends HTMLElement {
     }
 
     atom.views.updateDocument(this.renderItems.bind(this))
-    return atom.views.readDocument(this.readUIPropsFromDOM.bind(this))
+    atom.views.readDocument(this.readUIPropsFromDOM.bind(this))
   }
 
   moveSelectionUp () {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -46,10 +46,15 @@ class SuggestionListElement extends HTMLElement {
     this.registerMouseHandling()
     this.snippetParser = new SnippetParser()
     this.nodePool = []
+    this.innerHTML = ListTemplate
+    this.ol = this.querySelector('.list-group')
+    this.scroller = this.querySelector('.suggestion-list-scroller')
+    this.descriptionContainer = this.querySelector('.suggestion-description')
+    this.descriptionContent = this.querySelector('.suggestion-description-content')
+    this.descriptionMoreLink = this.querySelector('.suggestion-description-more-link')
   }
 
   attachedCallback () {
-    if (!this.ol) { this.renderList() }
     return this.itemsChanged()
   }
 
@@ -239,15 +244,6 @@ class SuggestionListElement extends HTMLElement {
       this.model.cancel()
       return event.abortKeyBinding()
     }
-  }
-
-  renderList () {
-    this.innerHTML = ListTemplate
-    this.ol = this.querySelector('.list-group')
-    this.scroller = this.querySelector('.suggestion-list-scroller')
-    this.descriptionContainer = this.querySelector('.suggestion-description')
-    this.descriptionContent = this.querySelector('.suggestion-description-content')
-    this.descriptionMoreLink = this.querySelector('.suggestion-description-more-link')
   }
 
   renderItems () {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -1,10 +1,8 @@
-'use babel'
-
-import { Disposable, CompositeDisposable } from 'atom'
-import SnippetParser from './snippet-parser'
-import { isString } from './type-helpers'
-import fuzzaldrinPlus from 'fuzzaldrin-plus'
-import marked from 'marked'
+const {Disposable, CompositeDisposable} = require('atom')
+const SnippetParser = require('./snippet-parser')
+const {isString} = require('./type-helpers')
+const fuzzaldrinPlus = require('fuzzaldrin-plus')
+const marked = require('marked')
 
 const ItemTemplate = `<span class="icon-container"></span>
   <span class="left-label"></span>
@@ -593,4 +591,4 @@ const escapeHtml = (html) => {
     .replace(/>/g, '&gt;')
 }
 
-export default SuggestionListElement = document.registerElement('autocomplete-suggestion-list', {prototype: SuggestionListElement.prototype}) // eslint-disable-line no-class-assign
+module.exports = document.registerElement('autocomplete-suggestion-list', {prototype: SuggestionListElement.prototype})

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -35,30 +35,25 @@ const SnippetStart = 1
 const SnippetEnd = 2
 const SnippetStartAndEnd = 3
 
-class SuggestionListElement extends HTMLElement {
-  createdCallback () {
+module.exports = class SuggestionListElement {
+  constructor (model) {
+    this.element = document.createElement('autocomplete-suggestion-list')
     this.maxItems = 200
     this.emptySnippetGroupRegex = /(\$\{\d+:\})|(\$\{\d+\})|(\$\d+)/ig
     this.slashesInSnippetRegex = /\\\\/g
     this.nodePool = null
     this.subscriptions = new CompositeDisposable()
-    this.classList.add('popover-list', 'select-list', 'autocomplete-suggestion-list')
+    this.element.classList.add('popover-list', 'select-list', 'autocomplete-suggestion-list')
     this.registerMouseHandling()
     this.snippetParser = new SnippetParser()
     this.nodePool = []
-    this.innerHTML = ListTemplate
-    this.ol = this.querySelector('.list-group')
-    this.scroller = this.querySelector('.suggestion-list-scroller')
-    this.descriptionContainer = this.querySelector('.suggestion-description')
-    this.descriptionContent = this.querySelector('.suggestion-description-content')
-    this.descriptionMoreLink = this.querySelector('.suggestion-description-more-link')
-  }
+    this.element.innerHTML = ListTemplate
+    this.ol = this.element.querySelector('.list-group')
+    this.scroller = this.element.querySelector('.suggestion-list-scroller')
+    this.descriptionContainer = this.element.querySelector('.suggestion-description')
+    this.descriptionContent = this.element.querySelector('.suggestion-description-content')
+    this.descriptionMoreLink = this.element.querySelector('.suggestion-description-more-link')
 
-  didAttach () {
-    this.itemsChanged()
-  }
-
-  initialize (model) {
     this.model = model
     if (this.model == null) { return }
     this.subscriptions.add(this.model.onDidChangeItems(this.itemsChanged.bind(this)))
@@ -81,15 +76,18 @@ class SuggestionListElement extends HTMLElement {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', useAlternateScoring => {
       this.useAlternateScoring = useAlternateScoring
     }))
-    return this
+  }
+
+  didAttach () {
+    this.itemsChanged()
   }
 
   // This should be unnecessary but the events we need to override
   // are handled at a level that can't be blocked by react synthetic
   // events because they are handled at the document
   registerMouseHandling () {
-    this.onmousewheel = event => event.stopPropagation()
-    this.onmousedown = (event) => {
+    this.element.onmousewheel = event => event.stopPropagation()
+    this.element.onmousedown = (event) => {
       const item = this.findItem(event)
       if (item && item.dataset && item.dataset.index) {
         this.selectedIndex = item.dataset.index
@@ -97,7 +95,7 @@ class SuggestionListElement extends HTMLElement {
       }
     }
 
-    this.onmouseup = (event) => {
+    this.element.onmouseup = (event) => {
       const item = this.findItem(event)
       if (item && item.dataset && item.dataset.index) {
         event.stopPropagation()
@@ -108,7 +106,7 @@ class SuggestionListElement extends HTMLElement {
 
   findItem (event) {
     let item = event.target
-    while (item.tagName !== 'LI' && item !== this) { item = item.parentNode }
+    while (item.tagName !== 'LI' && item !== this.element) { item = item.parentNode }
     if (item.tagName === 'LI') { return item }
   }
 
@@ -248,7 +246,7 @@ class SuggestionListElement extends HTMLElement {
 
   renderItems () {
     let left
-    this.style.width = null
+    this.element.style.width = null
     const items = (left = this.visibleItems()) != null ? left : []
     let longestDesc = 0
     let longestDescIndex = null
@@ -325,7 +323,7 @@ class SuggestionListElement extends HTMLElement {
     }
 
     if (!this.uiProps) { this.uiProps = {} }
-    this.uiProps.width = this.offsetWidth + 1
+    this.uiProps.width = this.element.offsetWidth + 1
     this.uiProps.marginLeft = 0
     if (wordContainer && wordContainer.offsetLeft) {
       this.uiProps.marginLeft = -wordContainer.offsetLeft
@@ -334,7 +332,7 @@ class SuggestionListElement extends HTMLElement {
       this.uiProps.itemHeight = this.selectedLi.offsetHeight
     }
     if (!this.uiProps.paddingHeight) {
-      this.uiProps.paddingHeight = parseInt(getComputedStyle(this)['padding-top']) + parseInt(getComputedStyle(this)['padding-bottom'])
+      this.uiProps.paddingHeight = parseInt(getComputedStyle(this.element)['padding-top']) + parseInt(getComputedStyle(this.element)['padding-bottom'])
       if (!this.uiProps.paddingHeight) {
         this.uiProps.paddingHeight = 0
       }
@@ -347,9 +345,9 @@ class SuggestionListElement extends HTMLElement {
 
   updateUIForChangedProps () {
     this.scroller.style['max-height'] = `${(this.maxVisibleSuggestions * this.uiProps.itemHeight) + this.uiProps.paddingHeight}px`
-    this.style.width = `${this.uiProps.width}px`
+    this.element.style.width = `${this.uiProps.width}px`
     if (this.suggestionListFollows === 'Word') {
-      this.style['margin-left'] = `${this.uiProps.marginLeft}px`
+      this.element.style['margin-left'] = `${this.uiProps.marginLeft}px`
     }
     return this.updateDescription()
   }
@@ -560,5 +558,3 @@ const escapeHtml = (html) => {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 }
-
-module.exports = document.registerElement('autocomplete-suggestion-list', {prototype: SuggestionListElement.prototype})

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -248,7 +248,7 @@ export default class SuggestionList {
       this.activeEditor = editor
       this.displayBufferPosition = bufferPosition
       const marker = this.suggestionMarker = editor.markBufferRange([bufferPosition, bufferPosition])
-      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail'})
+      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail', class: 'autocomplete-plus'})
       this.addBindings(editor)
     }
   }
@@ -262,7 +262,7 @@ export default class SuggestionList {
     }
     if (marker) {
       this.activeEditor = editor
-      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
+      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, class: 'autocomplete-plus'})
       return this.addBindings(editor)
     }
   }

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -227,13 +227,12 @@ export default class SuggestionList {
   }
 
   showAtBeginningOfPrefix (editor, prefix, followRawPrefix = false) {
-    if (!editor) {
-      return
-    }
-
-    let bufferPosition = editor.getCursorBufferPosition()
-    if (followRawPrefix || this.wordPrefixRegex.test(prefix)) {
-      bufferPosition = bufferPosition.translate([0, -prefix.length])
+    let bufferPosition
+    if (editor) {
+      bufferPosition = editor.getCursorBufferPosition()
+      if (followRawPrefix || this.wordPrefixRegex.test(prefix)) {
+        bufferPosition = bufferPosition.translate([0, -prefix.length])
+      }
     }
 
     if (this.activeEditor === editor) {
@@ -245,31 +244,45 @@ export default class SuggestionList {
       }
     } else {
       this.destroyOverlay()
-      this.activeEditor = editor
-      this.displayBufferPosition = bufferPosition
-      const marker = this.suggestionMarker = editor.markBufferRange([bufferPosition, bufferPosition])
-      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail', class: 'autocomplete-plus'})
-      this.addBindings(editor)
+      if (editor) {
+        this.activeEditor = editor
+        this.displayBufferPosition = bufferPosition
+        const marker = this.suggestionMarker = editor.markBufferRange([bufferPosition, bufferPosition])
+        this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail', class: 'autocomplete-plus'})
+        const editorElement = atom.views.getView(this.activeEditor)
+        if (editorElement && editorElement.classList) {
+          editorElement.classList.add('autocomplete-active')
+        }
+        this.addBindings(editor)
+      }
     }
   }
 
   showAtCursorPosition (editor) {
-    if (this.activeEditor === editor || (editor == null)) { return }
     this.destroyOverlay()
+
+    if (this.activeEditor === editor || (editor == null)) { return }
     let marker
     if (editor.getLastCursor()) {
       marker = editor.getLastCursor().getMarker()
     }
     if (marker) {
       this.activeEditor = editor
+      const editorElement = atom.views.getView(this.activeEditor)
+      if (editorElement && editorElement.classList) {
+        editorElement.classList.add('autocomplete-active')
+      }
       this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, class: 'autocomplete-plus'})
       return this.addBindings(editor)
     }
   }
 
   hide () {
-    if (this.activeEditor === null) { return }
     this.destroyOverlay()
+    if (this.activeEditor === null) {
+      return
+    }
+
     if (this.bindings && this.bindings.dispose) {
       this.bindings.dispose()
     }
@@ -283,6 +296,10 @@ export default class SuggestionList {
       this.suggestionMarker.destroy()
     } else if (this.overlayDecoration && this.overlayDecoration.destroy) {
       this.overlayDecoration.destroy()
+    }
+    const editorElement = atom.views.getView(this.activeEditor)
+    if (editorElement && editorElement.classList) {
+      editorElement.classList.remove('autocomplete-active')
     }
     this.suggestionMarker = undefined
     this.overlayDecoration = undefined

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -36,7 +36,7 @@ export default class SuggestionList {
 
   get suggestionListElement () {
     if (!this._suggestionListElement) {
-      this._suggestionListElement = new SuggestionListElement().initialize(this)
+      this._suggestionListElement = new SuggestionListElement(this)
     }
 
     return this._suggestionListElement

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -253,6 +253,8 @@ export default class SuggestionList {
         if (editorElement && editorElement.classList) {
           editorElement.classList.add('autocomplete-active')
         }
+
+        process.nextTick(() => { atom.views.getView(this).didAttach() })
         this.addBindings(editor)
       }
     }
@@ -272,7 +274,9 @@ export default class SuggestionList {
       if (editorElement && editorElement.classList) {
         editorElement.classList.add('autocomplete-active')
       }
+
       this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, class: 'autocomplete-plus'})
+      process.nextTick(() => { atom.views.getView(this).didAttach() })
       return this.addBindings(editor)
     }
   }

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -2,6 +2,7 @@
 
 import { Emitter, CompositeDisposable } from 'atom'
 import { UnicodeLetters } from './unicode-helpers'
+import SuggestionListElement from './suggestion-list-element'
 
 export default class SuggestionList {
   constructor () {
@@ -31,6 +32,14 @@ export default class SuggestionList {
       }
       return this.wordPrefixRegex
     }))
+  }
+
+  get suggestionListElement () {
+    if (!this._suggestionListElement) {
+      this._suggestionListElement = new SuggestionListElement().initialize(this)
+    }
+
+    return this._suggestionListElement
   }
 
   addBindings (editor) {
@@ -248,13 +257,13 @@ export default class SuggestionList {
         this.activeEditor = editor
         this.displayBufferPosition = bufferPosition
         const marker = this.suggestionMarker = editor.markBufferRange([bufferPosition, bufferPosition])
-        this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail', class: 'autocomplete-plus'})
+        this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this.suggestionListElement, position: 'tail', class: 'autocomplete-plus'})
         const editorElement = atom.views.getView(this.activeEditor)
         if (editorElement && editorElement.classList) {
           editorElement.classList.add('autocomplete-active')
         }
 
-        process.nextTick(() => { atom.views.getView(this).didAttach() })
+        process.nextTick(() => { this.suggestionListElement.didAttach() })
         this.addBindings(editor)
       }
     }
@@ -275,8 +284,8 @@ export default class SuggestionList {
         editorElement.classList.add('autocomplete-active')
       }
 
-      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, class: 'autocomplete-plus'})
-      process.nextTick(() => { atom.views.getView(this).didAttach() })
+      this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this.suggestionListElement, class: 'autocomplete-plus'})
+      process.nextTick(() => { this.suggestionListElement.didAttach() })
       return this.addBindings(editor)
     }
   }

--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -72,7 +72,7 @@ describe('Async providers', () => {
 
       runs(() => {
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        expect(suggestionListView.querySelector('li .right-label')).toHaveText('asyncProvided')
+        expect(suggestionListView.element.querySelector('li .right-label')).toHaveText('asyncProvided')
       })
     })
   })

--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -71,7 +71,7 @@ describe('Async providers', () => {
       waitForAutocomplete()
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.querySelector('li .right-label')).toHaveText('asyncProvided')
       })
     })

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -108,7 +108,7 @@ describe('Autocomplete Manager', () => {
         didAutocomplete = false
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
         // Accept suggestion
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
         expect(editor.getBuffer().getLastLine()).toEqual('function')
       })

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -109,7 +109,7 @@ describe('Autocomplete Manager', () => {
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
         // Accept suggestion
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        atom.commands.dispatch(suggestionListView.element, 'autocomplete-plus:confirm')
         expect(editor.getBuffer().getLastLine()).toEqual('function')
       })
     })

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -2286,7 +2286,7 @@ defm`
       waitForAutocomplete()
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.scrollWidth).toBe(suggestionListView.offsetWidth)
       })
     })

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -260,8 +260,8 @@ describe('Provider API Legacy', () => {
       runs(() => {
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
 
-        expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
-        expect(suggestionListView.querySelector('li')).toHaveClass('ohai')
+        expect(suggestionListView.element.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
+        expect(suggestionListView.element.querySelector('li')).toHaveClass('ohai')
       })
     })
 

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -258,7 +258,7 @@ describe('Provider API Legacy', () => {
       triggerAutocompletion(editor, true, 'o')
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
 
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('li')).toHaveClass('ohai')

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -111,7 +111,7 @@ describe('Provider API', () => {
       triggerAutocompletion(editor, true, 'o')
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('.word')).toHaveText('ohai')
         expect(suggestionListView.querySelector('.suggestion-description-content')).toHaveText('There be documentation')
@@ -138,7 +138,7 @@ describe('Provider API', () => {
       triggerAutocompletion(editor, true, 'o')
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.querySelector('.word')).toHaveText('displayOHAI')
       })
     })
@@ -161,7 +161,7 @@ describe('Provider API', () => {
       triggerAutocompletion(editor, true, 'o')
 
       runs(() => {
-        let suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         let content = suggestionListView.querySelector('.suggestion-description-content')
         let moreLink = suggestionListView.querySelector('.suggestion-description-more-link')
         expect(content).toHaveText('There be documentation')

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -112,10 +112,10 @@ describe('Provider API', () => {
 
       runs(() => {
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
-        expect(suggestionListView.querySelector('.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('.suggestion-description-content')).toHaveText('There be documentation')
-        expect(suggestionListView.querySelector('.suggestion-description-more-link').style.display).toBe('none')
+        expect(suggestionListView.element.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
+        expect(suggestionListView.element.querySelector('.word')).toHaveText('ohai')
+        expect(suggestionListView.element.querySelector('.suggestion-description-content')).toHaveText('There be documentation')
+        expect(suggestionListView.element.querySelector('.suggestion-description-more-link').style.display).toBe('none')
       })
     })
 
@@ -139,7 +139,7 @@ describe('Provider API', () => {
 
       runs(() => {
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        expect(suggestionListView.querySelector('.word')).toHaveText('displayOHAI')
+        expect(suggestionListView.element.querySelector('.word')).toHaveText('displayOHAI')
       })
     })
 
@@ -162,8 +162,8 @@ describe('Provider API', () => {
 
       runs(() => {
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        let content = suggestionListView.querySelector('.suggestion-description-content')
-        let moreLink = suggestionListView.querySelector('.suggestion-description-more-link')
+        let content = suggestionListView.element.querySelector('.suggestion-description-content')
+        let moreLink = suggestionListView.element.querySelector('.suggestion-description-more-link')
         expect(content).toHaveText('There be documentation')
         expect(moreLink).toHaveText('More..')
         expect(moreLink.style.display).toBe('inline')

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -17,7 +17,7 @@ describe('Suggestion List Element', () => {
   })
 
   describe('renderItem', () => {
-    beforeEach(() => jasmine.attachToDOM(suggestionListElement))
+    beforeEach(() => jasmine.attachToDOM(suggestionListElement.element))
 
     it('HTML escapes displayText', () => {
       let suggestion = {text: 'Animal<Cat>'}


### PR DESCRIPTION
This pull request stops registering custom elements during startup and uses simple javascript objects that internally manage a DOM element instead.

/cc: @ungb for 👀