### PR TITLE
Allow suggestion list to use 75% of viewport width

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -19,7 +19,8 @@ autocomplete-suggestion-list.select-list.popover-list {
   width: auto;
   display: inline-block;
   min-width: 200px;
-  max-width: 800px;
+  max-width: 75vw;
+  width: auto;
   padding: 0;
   overflow: hidden;
   color: @text-color;
@@ -175,18 +176,6 @@ autocomplete-suggestion-list {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .left-label {
-    max-width: 150px;
-  }
-
-  .right-label {
-    max-width: 150px;
-  }
-
-  .word {
-    max-width: 430px; // magic number to also fit the icon-container + scrollbar in the 800px max-width
   }
 
   .make-type-icon(attribute, @syntax-color-attribute);

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -60,6 +60,8 @@ autocomplete-suggestion-list.select-list.popover-list {
   ol.list-group {
     margin-top: 0;
     display: table;
+    width: 100%;
+    margin-right: 10px; // Needed to prevent horizontal scrolling when right label is too long
 
     li {
       display: table-row;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -20,7 +20,8 @@ autocomplete-suggestion-list.select-list.popover-list {
   display: inline-block;
   min-width: 200px;
   max-width: 75vw;
-  width: auto;
+  display: table;
+  width: 1%;
   padding: 0;
   overflow: hidden;
   color: @text-color;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -16,12 +16,10 @@ atom-overlay.autocomplete-plus {
 }
 
 autocomplete-suggestion-list.select-list.popover-list {
-  width: auto;
+  width: auto !important; // TODO: Can be removed once the inline style is gone
   display: inline-block;
   min-width: 200px;
-  max-width: 75vw;
   display: table;
-  width: 1%;
   padding: 0;
   overflow: hidden;
   color: @text-color;
@@ -36,9 +34,12 @@ autocomplete-suggestion-list.select-list.popover-list {
     padding-right: @item-side-padding;
     min-height: @row-line-height;
     line-height: 1.3;
-
     background: darken(@overlay-background-color, 4%);
     border-radius: 0 0 @component-border-radius @component-border-radius;
+
+    // let the other sibling decide how large the container should be
+    width: min-content;
+    min-width: 100%;
   }
 
   .suggestion-description-content {
@@ -60,8 +61,6 @@ autocomplete-suggestion-list.select-list.popover-list {
   ol.list-group {
     margin-top: 0;
     display: table;
-    width: 100%;
-    margin-right: 10px; // Needed to prevent horizontal scrolling when right label is too long
 
     li {
       display: table-row;
@@ -173,6 +172,16 @@ autocomplete-suggestion-list {
   }
 
   // Here we set the max width of the popup
+  .left-label {
+    max-width: 20vw;
+  }
+  .word {
+    max-width: 35vw;
+  }
+  .right-label {
+    max-width: 25vw;
+  }
+
   .word, .left-label, .right-label {
     white-space: nowrap;
     overflow: hidden;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -19,7 +19,6 @@ autocomplete-suggestion-list.select-list.popover-list {
   width: auto !important; // TODO: Can be removed once the inline style is gone
   display: inline-block;
   min-width: 200px;
-  display: table;
   padding: 0;
   overflow: hidden;
   color: @text-color;


### PR DESCRIPTION
- Restricting to 800px is unnecessarily small on large displays
- Restricting the size of different portions of the suggestion list (left / word / right) results in unnecessary truncation of text
- It just looks nicer 😄 

Before:
![screen shot 2017-03-03 at 4 27 51 pm](https://cloud.githubusercontent.com/assets/744740/23572876/5f9babc8-002f-11e7-8b33-ed4113585296.png)

After:
![screen shot 2017-03-03 at 4 29 20 pm](https://cloud.githubusercontent.com/assets/744740/23572878/64c4729c-002f-11e7-9981-669813a9c302.png)

/cc @AndreaGriffiths11 @ungb @nmote 

- Fixes #670 
- Fixes #566 
- Fixes https://github.com/joefitzgerald/go-plus/issues/504
- #389 worth testing for