### PR TITLE
Raise z-index

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -12,7 +12,7 @@
 @item-side-padding: .6em;
 
 atom-overlay.autocomplete-plus {
-  z-index: 5;
+  z-index: 12; // higher than docks
 }
 
 autocomplete-suggestion-list.select-list.popover-list {


### PR DESCRIPTION
### Description of the Change

This raises the `z-index` to `12`.

### Benefits

Fixes the docks border from being on top.

![dock-over-autocomplete](https://cloud.githubusercontent.com/assets/2766036/24584053/a748ac5e-172d-11e7-991d-a5546d15befa.png)


### Possible Drawbacks

Now autocomplete might cover other things. Tooltips and modals seem fine, tough.


### Applicable Issues

Fixes #834
