### PR TITLE
Optionally dismiss suggestion list on up/down instead of cycling.

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -84,6 +84,9 @@ module.exports = class SuggestionListElement {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', useAlternateScoring => {
       this.useAlternateScoring = useAlternateScoring
     }))
+    this.subscriptions.add(atom.config.observe('autocomplete-plus.cycleSuggestions', cycleSuggestions => {
+      this.cycleSuggestions = cycleSuggestions
+    }))
 
     process.nextTick(() => this.render())
   }
@@ -175,16 +178,20 @@ module.exports = class SuggestionListElement {
   moveSelectionUp () {
     if (this.selectedIndex > 0) {
       return this.setSelectedIndex(this.selectedIndex - 1)
-    } else {
+    } else if (this.cycleSuggestions) {
       return this.setSelectedIndex(this.visibleItems().length - 1)
+    } else {
+      return this.model.cancel()
     }
   }
 
   moveSelectionDown () {
     if (this.selectedIndex < (this.visibleItems().length - 1)) {
       return this.setSelectedIndex(this.selectedIndex + 1)
-    } else {
+    } else if (this.cycleSuggestions) {
       return this.setSelectedIndex(0)
+    } else {
+      return this.model.cancel()
     }
   }
 

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -84,8 +84,8 @@ module.exports = class SuggestionListElement {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', useAlternateScoring => {
       this.useAlternateScoring = useAlternateScoring
     }))
-    this.subscriptions.add(atom.config.observe('autocomplete-plus.cycleSuggestions', cycleSuggestions => {
-      this.cycleSuggestions = cycleSuggestions
+    this.subscriptions.add(atom.config.observe('autocomplete-plus.moveToCancel', moveToCancel => {
+      this.moveToCancel = moveToCancel
     }))
 
     process.nextTick(() => this.render())
@@ -178,22 +178,22 @@ module.exports = class SuggestionListElement {
   moveSelectionUp () {
     if (this.selectedIndex > 0) {
       return this.setSelectedIndex(this.selectedIndex - 1)
-    } else if (this.cycleSuggestions) {
-      return this.setSelectedIndex(this.visibleItems().length - 1)
-    } else {
+    } else if (this.moveToCancel) {
       this.model.activeEditor.moveUp(1)
       return this.model.cancel()
+    } else {
+      return this.setSelectedIndex(this.visibleItems().length - 1)
     }
   }
 
   moveSelectionDown () {
     if (this.selectedIndex < (this.visibleItems().length - 1)) {
       return this.setSelectedIndex(this.selectedIndex + 1)
-    } else if (this.cycleSuggestions) {
-      return this.setSelectedIndex(0)
-    } else {
+    } else if (this.moveToCancel) {
       this.model.activeEditor.moveDown(1)
       return this.model.cancel()
+    } else {
+      return this.setSelectedIndex(0)
     }
   }
 

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -181,6 +181,7 @@ module.exports = class SuggestionListElement {
     } else if (this.cycleSuggestions) {
       return this.setSelectedIndex(this.visibleItems().length - 1)
     } else {
+      this.model.activeEditor.moveUp(1)
       return this.model.cancel()
     }
   }
@@ -191,6 +192,7 @@ module.exports = class SuggestionListElement {
     } else if (this.cycleSuggestions) {
       return this.setSelectedIndex(0)
     } else {
+      this.model.activeEditor.moveDown(1)
       return this.model.cancel()
     }
   }

--- a/package.json
+++ b/package.json
@@ -237,6 +237,12 @@
         }
       ],
       "order": 22
+    },
+    "cycleSuggestions": {
+      "description": "Cycle through the list when moving up and down instead of dismissing it.",
+      "type": "boolean",
+      "default": true,
+      "order": 23
     }
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -238,10 +238,10 @@
       ],
       "order": 22
     },
-    "cycleSuggestions": {
-      "description": "Cycle through the list when moving up and down instead of dismissing it.",
+    "moveToCancel": {
+      "description": "Moving up when the first item is selected or down when the last item is selected cancels the suggestion list.",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "order": 23
     }
   },


### PR DESCRIPTION
### Description of the Change
I often found myself pining for the behavior of Sublime Text's autocompletion widget, which permitted navigation with one's arrow keys, à la the "Core Movement Commands" setting here, but wouldn't be so presumptuous as to _hijack_ them and would politely yield control and see itself out if one tried to navigate above its first suggestion or below its last. It was especially handy for breaking out of autocompletion without reaching for <kbd>Escape</kbd>---one could just hit the up arrow and get on with one's life---but it was generally nice not to spend the occasional confused millisecond trying to make the cursor move when a suggestion list was in view.

Implementing the change was super straightforward. There's a new preference, "Cycle Suggestions": in its presence, the behavior is unchanged; in its absence, trying to move beyond the boundaries of the list dismisses it and fires a new movement in the editor.

![2017-04-15 06_42_06](https://cloud.githubusercontent.com/assets/2207980/25063089/b25431ce-21a8-11e7-9bc3-3f3c1ec5dfad.gif)

### Alternate Designs
I briefly tried it without forcing the cursor up/down a line when the list was dismissed. If anything this was _more_ frustrating than getting caught in a loop, as the keystroke appeared to do nothing at all.

### Benefits
Never again will an element I'm usually only half-attending to take over my arrow keys.

### Possible Drawbacks
Anyone who enables this feature and dislikes it will lose valuable seconds disabling it again.

### Applicable Issues
Apparently I'm all alone here.
