### PR TITLE
Increase min width

### DIFF
--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -1190,7 +1190,7 @@ describe('Autocomplete Manager', () => {
         })
 
         runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 11]))
+          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
 
           editor.insertText(' ')
           editor.insertText('a')

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -18,7 +18,7 @@ atom-overlay.autocomplete-plus {
 autocomplete-suggestion-list.select-list.popover-list {
   width: auto !important; // TODO: Can be removed once the inline style is gone
   display: inline-block;
-  min-width: 200px;
+  min-width: 250px;
   padding: 0;
   overflow: hidden;
   color: @text-color;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -18,7 +18,7 @@ atom-overlay.autocomplete-plus {
 autocomplete-suggestion-list.select-list.popover-list {
   width: auto !important; // TODO: Can be removed once the inline style is gone
   display: inline-block;
-  min-width: 250px;
+  min-width: 243px; // Try and fail until the specs pass
   padding: 0;
   overflow: hidden;
   color: @text-color;


### PR DESCRIPTION
### Description of the Change

This increases the minimum width from `200px` to `243px`.

Before | After
--- | ---
![screen shot 2017-05-12 at 4 13 58 pm](https://cloud.githubusercontent.com/assets/378023/25987238/14943178-372e-11e7-999b-e98775acd8f1.png) | ![screen shot 2017-05-12 at 4 13 37 pm](https://cloud.githubusercontent.com/assets/378023/25987237/1466b068-372e-11e7-9c1f-d7518bf464f8.png)

### Alternate Designs

~~Many alternatives would be possible, but 250 seems a nice number.~~
Actually, specs failed with `250px`, so after some trial and error, `243px` seems to pass.

### Benefits

Makes sure the description isn't too narrow and hard to read.

### Possible Drawbacks

Covers more of the horizontal code.

### Applicable Issues

Based on [this feedback](https://github.com/atom/autocomplete-plus/pull/827#issuecomment-297872777).
