### PR TITLE
Adjust test to work when TextBuffer.save is made async

### DIFF
--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -102,10 +102,14 @@ describe('Autocomplete Manager', () => {
       editor.insertText('a')
       waitForAutocomplete()
 
-      runs(() => {
+      waitsFor((done) => {
+        editor.getBuffer().onDidSave(() => {
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          done()
+        })
+
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
         editor.saveAs(path.join(directory, 'spec', 'tmp', 'issue-11.js'))
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
     })
 


### PR DESCRIPTION
The `TextBuffer.save` method is going to become async in https://github.com/atom/atom/pull/14435; instead of doing a synchronous write, it will initiate an asynchronous write and return a promise when the write completes. This shouldn't affect the user-facing functionality of many packages; but several packages may have test failures.

This updates the one test in `autocomplete-plus` that broke due to this change to work regardless of whether `save` is synchronous or asynchronous.