### PR TITLE
Prevent premature suggestion list closing when following cursor

### DIFF
--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -270,9 +270,9 @@ export default class SuggestionList {
   }
 
   showAtCursorPosition (editor) {
+    if (this.activeEditor === editor || (editor == null)) { return }
     this.destroyOverlay()
 
-    if (this.activeEditor === editor || (editor == null)) { return }
     let marker
     if (editor.getLastCursor()) {
       marker = editor.getLastCursor().getMarker()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -1109,6 +1109,46 @@ describe('Autocomplete Manager', () => {
           expect(suggestionList.style['margin-left']).toBeFalsy()
         })
       })
+
+      it('closes the suggestion list if the user keeps typing', () => {
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+        // Trigger an autocompletion
+        editor.moveToBottom()
+        editor.insertText('a')
+        waitForAutocomplete()
+
+        runs(() => {
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+          editor.insertText('b')
+          waitForAutocomplete()
+        })
+
+        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+      })
+
+      it('keeps the suggestion list visible if the user keeps typing', () => {
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+        // Trigger an autocompletion
+        editor.moveToBottom()
+        editor.insertText('a')
+        waitForAutocomplete()
+
+        runs(() => {
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+          editor.insertText('c')
+          waitForAutocomplete()
+        })
+
+        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+      })
     })
 
     describe("when autocomplete-plus.suggestionListFollows is 'Word'", () => {


### PR DESCRIPTION
When `autocomplete.suggestionListFollows` is set to `"Cursor"`, the overlay decoration was being destroyed prematurely in `showAtCursorPosition()`. Only destroy the existing overlay if the Editor has changed and we're about to create a new one.

Fixes #850 with a hat tip to @50Wliu for doing the initial investigative work :smile:

- [x] Sleuth around the history a little to see why the `destroyOverlay()` call was there to begin with, to make sure I'm not breaking something else.
- [x] Add a spec to prevent regressions.