### PR TITLE
Listeners for provider additions and removals

### DIFF
--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import { CompositeDisposable, Disposable } from 'atom'
+import { CompositeDisposable, Disposable, Emitter } from 'atom'
 import { isFunction, isString } from './type-helpers'
 import semver from 'semver'
 import { Selector } from 'selector-kit'
@@ -35,6 +35,7 @@ export default class ProviderManager {
     this.globalBlacklist = new CompositeDisposable()
     this.subscriptions.add(this.globalBlacklist)
     this.providers = []
+    this.emitter = new Emitter()
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableBuiltinProvider', value => this.toggleDefaultProvider(value)))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.scopeBlacklist', value => this.setGlobalBlacklist(value)))
   }
@@ -145,6 +146,10 @@ export default class ProviderManager {
     }
   }
 
+  getDefaultProvider () {
+    return this.defaultProvider
+  }
+
   setGlobalBlacklist (globalBlacklist) {
     this.globalBlacklistSelectors = null
     if (globalBlacklist && globalBlacklist.length) {
@@ -185,15 +190,21 @@ export default class ProviderManager {
   addProvider (provider, apiVersion = '3.0.0') {
     if (this.isProviderRegistered(provider)) { return }
     this.providers.push(new ProviderMetadata(provider, apiVersion))
-    if (provider.dispose != null) { return this.subscriptions.add(provider) }
+    if (provider.dispose != null) {
+      var result = this.subscriptions.add(provider)
+    }
+    this.emitter.emit('did-add-provider', provider)
+    return result
   }
 
   removeProvider (provider) {
     if (!this.providers) { return }
+    var removed = false
     for (let i = 0; i < this.providers.length; i++) {
       const providerMetadata = this.providers[i]
       if (providerMetadata.provider === provider) {
         this.providers.splice(i, 1)
+        removed = true
         break
       }
     }
@@ -202,6 +213,7 @@ export default class ProviderManager {
         this.subscriptions.remove(provider)
       }
     }
+    if (removed) this.emitter.emit('did-remove-provider', provider)
   }
 
   registerProvider (provider, apiVersion = '3.0.0') {
@@ -276,6 +288,17 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
     }
 
     return disposable
+  }
+
+  observeProviders (callback) {
+    for (let i = 0; i < this.providers.length; i++) {
+      callback(this.providers[i].provider)
+    }
+    return this.emitter.on('did-add-provider', callback)
+  }
+
+  onDidRemoveProvider (callback) {
+    return this.emitter.on('did-remove-provider', callback)
   }
 }
 

--- a/spec/provider-manager-spec.js
+++ b/spec/provider-manager-spec.js
@@ -86,6 +86,42 @@ describe('Provider Manager', () => {
       expect(hasDisposable(providerManager.subscriptions, testProvider)).toBe(false)
     })
 
+    it('can let its providers be observed', () => {
+      let spy = jasmine.createSpy()
+      let disposable = providerManager.observeProviders(spy)
+      expect(spy.calls.length).toBe(1)
+      expect(spy.argsForCall[0][0]).toBe(providerManager.getDefaultProvider())
+
+      let testProvider1 = Object.assign({}, testProvider)
+      providerManager.addProvider(testProvider1)
+      expect(spy.calls.length).toBe(2)
+      expect(spy.argsForCall[1][0]).toBe(testProvider1)
+
+      disposable.dispose()
+
+      let testProvider2 = Object.assign({}, testProvider)
+      providerManager.addProvider(testProvider2)
+      expect(spy.calls.length).toBe(2)
+    })
+
+    it('can execute a callback when removing a provider', () => {
+      providerManager.addProvider(testProvider)
+
+      let spy = jasmine.createSpy()
+      let disposable = providerManager.onDidRemoveProvider(spy)
+
+      providerManager.addProvider(testProvider)
+      providerManager.removeProvider(testProvider)
+      expect(spy.calls.length).toBe(1)
+      expect(spy.argsForCall[0][0]).toBe(testProvider)
+
+      disposable.dispose()
+
+      providerManager.addProvider(testProvider)
+      providerManager.removeProvider(testProvider)
+      expect(spy.calls.length).toBe(1)
+    })
+
     it('can identify a provider with a missing getSuggestions', () => {
       let bogusProvider = {
         badgetSuggestions (options) {},


### PR DESCRIPTION
### Description of the Change

This change:

- Implements the ability to add listeners for when autocompletion providers are added or removed.
- Exposes the default autocompletion provider.

This is an implementation of the proposal in atom/find-and-replace#710 from @as-cii.

### Benefits

Autocompletion providers can be more reliably accessed when they are added or removed. The default autocompletion provider can be identified without introspection.