### PR TITLE
Labels for autocompletion providers that editors can subscribe to

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Then add these to your keymap file:
 * Disable autocomplete for file(s) via blacklisting, e.g. `*.md` to blacklist Markdown files
 * Disable autocomplete for editor scope(s) via blacklisting
 * Expands a snippet if an autocomplete+ provider includes one in a suggestion
+* Allows external editors to register for autocompletions
 
 ## Provider API
 
@@ -80,3 +81,7 @@ Great autocomplete depends on having great autocomplete providers. If there is n
 ## `SymbolProvider` Configuration
 
 If the default `SymbolProvider` is missing useful information for the language / grammar you're working with, please take a look at the [`SymbolProvider` Config API](https://github.com/atom/autocomplete-plus/wiki/SymbolProvider-Config-API).
+
+## `AutocompleteManager` API
+
+The `AutocompleteManager` is exposed as a [provided service](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/). Its main public method is `watchEditor` which allows external editors to register for autocompletions from providers with a given set of labels.

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -24,6 +24,7 @@ export default class AutocompleteManager {
     this.compositionInProgress = false
     this.disposed = false
     this.editor = null
+    this.editorLabels = null
     this.editorSubscriptions = null
     this.editorView = null
     this.providerManager = null
@@ -45,6 +46,7 @@ export default class AutocompleteManager {
     this.toggleActivationForBufferChange = this.toggleActivationForBufferChange.bind(this)
     this.showOrHideSuggestionListForBufferChanges = this.showOrHideSuggestionListForBufferChanges.bind(this)
     this.showOrHideSuggestionListForBufferChange = this.showOrHideSuggestionListForBufferChange.bind(this)
+    this.watchEditor = this.watchEditor.bind(this)
     this.subscriptions = new CompositeDisposable()
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
@@ -70,8 +72,8 @@ export default class AutocompleteManager {
     this.snippetsManager = snippetsManager
   }
 
-  updateCurrentEditor (currentEditor) {
-    if (!currentEditor || currentEditor === this.editor) { return }
+  updateCurrentEditor (currentEditor, labels) {
+    if (currentEditor === this.editor) { return }
     if (this.editorSubscriptions) {
       this.editorSubscriptions.dispose()
     }
@@ -85,8 +87,10 @@ export default class AutocompleteManager {
 
     if (!this.editorIsValid(currentEditor)) { return }
 
-    // Track the new editor, editorView, and buffer
+    // Track the new editor, editorView, and buffer and set
+    // the labels for its providers.
     this.editor = currentEditor
+    this.editorLabels = labels
     this.editorView = atom.views.getView(this.editor)
     this.buffer = this.editor.getBuffer()
 
@@ -132,14 +136,42 @@ export default class AutocompleteManager {
     if (typeof atom.workspace.isTextEditor === 'function') {
       return atom.workspace.isTextEditor(editor)
     } else {
-      if (editor == null) { return false }
+      if (!editor) { return false }
       // Should we disqualify TextEditors with the Grammar text.plain.null-grammar?
       return (editor.getText != null)
     }
   }
 
+  // Makes the autocomplete manager watch the `editor`.
+  // When the watched `editor` is focused, it will provide autocompletions from
+  // providers with the given `labels`.
+  //
+  // Returns a {Disposable} to stop watching the `editor`.
+  watchEditor (editor, labels) {
+    let view = atom.views.getView(editor)
+
+    if (view.hasFocus()) {
+      this.updateCurrentEditor(editor, labels)
+    }
+
+    let listener = (element) => this.updateCurrentEditor(editor, labels)
+    view.addEventListener('focus', listener)
+
+    let disposable = new Disposable(() => {
+      view.removeEventListener('focus', listener)
+      if (this.editor === editor) {
+        this.updateCurrentEditor(null)
+      }
+    })
+    this.subscriptions.add(disposable)
+    return new Disposable(() => {
+      disposable.dispose()
+      this.subscriptions.remove(disposable)
+    })
+  }
+
   handleEvents () {
-    this.subscriptions.add(atom.workspace.observeActiveTextEditor((editor) => { this.updateCurrentEditor(editor) }))
+    this.subscriptions.add(atom.workspace.observeActiveTextEditor((editor) => { this.updateCurrentEditor(editor, ['workspace-center']) }))
 
     // Watch config values
     this.subscriptions.add(atom.config.observe('autosave.enabled', (value) => { this.autosaveEnabled = value }))
@@ -199,7 +231,7 @@ export default class AutocompleteManager {
 
   getSuggestionsFromProviders (options) {
     let suggestionsPromise
-    const providers = this.providerManager.applicableProviders(options.scopeDescriptor)
+    const providers = this.providerManager.applicableProviders(this.editorLabels, options.scopeDescriptor)
 
     const providerPromises = []
     providers.forEach(provider => {

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -71,7 +71,7 @@ export default class AutocompleteManager {
   }
 
   updateCurrentEditor (currentEditor) {
-    if ((currentEditor == null) || currentEditor === this.editor) { return }
+    if (!currentEditor || currentEditor === this.editor) { return }
     if (this.editorSubscriptions) {
       this.editorSubscriptions.dispose()
     }
@@ -139,15 +139,7 @@ export default class AutocompleteManager {
   }
 
   handleEvents () {
-    this.subscriptions.add(atom.textEditors.observe((editor) => {
-      const view = atom.views.getView(editor)
-      if (view === document.activeElement.closest('atom-text-editor')) {
-        this.updateCurrentEditor(editor)
-      }
-      view.addEventListener('focus', (element) => {
-        this.updateCurrentEditor(editor)
-      })
-    }))
+    this.subscriptions.add(atom.workspace.observeActiveTextEditor((editor) => { this.updateCurrentEditor(editor) }))
 
     // Watch config values
     this.subscriptions.add(atom.config.observe('autosave.enabled', (value) => { this.autosaveEnabled = value }))
@@ -207,7 +199,7 @@ export default class AutocompleteManager {
 
   getSuggestionsFromProviders (options) {
     let suggestionsPromise
-    const providers = this.providerManager.applicableProviders(options.editor, options.scopeDescriptor)
+    const providers = this.providerManager.applicableProviders(options.scopeDescriptor)
 
     const providerPromises = []
     providers.forEach(provider => {

--- a/lib/fuzzy-provider.js
+++ b/lib/fuzzy-provider.js
@@ -16,6 +16,7 @@ export default class FuzzyProvider {
     this.editor = null
     this.buffer = null
 
+    this.labels = ['workspace-center', 'default', 'fuzzy-provider']
     this.scopeSelector = '*'
     this.inclusionPriority = 0
     this.suggestionPriority = 0

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -49,9 +49,8 @@ export default class ProviderManager {
     this.providers = null
   }
 
-  applicableProviders (editor, scopeDescriptor) {
-    let providers = this.filterProvidersByEditor(this.providers, editor)
-    providers = this.filterProvidersByScopeDescriptor(providers, scopeDescriptor)
+  applicableProviders (scopeDescriptor) {
+    let providers = this.filterProvidersByScopeDescriptor(this.providers, scopeDescriptor)
     providers = this.sortProviders(providers, scopeDescriptor)
     providers = this.filterProvidersByExcludeLowerPriority(providers)
     return this.removeMetadata(providers)
@@ -100,10 +99,6 @@ export default class ProviderManager {
       return difference
     }
     )
-  }
-
-  filterProvidersByEditor (providers, editor) {
-    return providers.filter(providerMetadata => providerMetadata.matchesEditor(editor))
   }
 
   filterProvidersByExcludeLowerPriority (providers) {

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -19,7 +19,7 @@ export default class ProviderManager {
   constructor () {
     this.defaultProvider = null
     this.defaultProviderRegistration = null
-    this.providers = null
+    this.providers = new Map()
     this.store = null
     this.subscriptions = null
     this.globalBlacklist = null
@@ -34,7 +34,6 @@ export default class ProviderManager {
     this.subscriptions = new CompositeDisposable()
     this.globalBlacklist = new CompositeDisposable()
     this.subscriptions.add(this.globalBlacklist)
-    this.providers = []
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableBuiltinProvider', value => this.toggleDefaultProvider(value)))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.scopeBlacklist', value => this.setGlobalBlacklist(value)))
   }
@@ -49,11 +48,22 @@ export default class ProviderManager {
     this.providers = null
   }
 
-  applicableProviders (scopeDescriptor) {
-    let providers = this.filterProvidersByScopeDescriptor(this.providers, scopeDescriptor)
+  applicableProviders (labels, scopeDescriptor) {
+    let providers = this.getProvidersForLabels(labels)
+    providers = this.filterProvidersByScopeDescriptor(providers, scopeDescriptor)
     providers = this.sortProviders(providers, scopeDescriptor)
     providers = this.filterProvidersByExcludeLowerPriority(providers)
     return this.removeMetadata(providers)
+  }
+
+  getProvidersForLabels (labels) {
+    let result = new Set()
+    for (let label of labels) {
+      if (this.providers.has(label)) {
+        this.providers.get(label).forEach(result.add.bind(result))
+      }
+    }
+    return Array.from(result)
   }
 
   filterProvidersByScopeDescriptor (providers, scopeDescriptor) {
@@ -160,9 +170,11 @@ export default class ProviderManager {
   }
 
   metadataForProvider (provider) {
-    for (let i = 0; i < this.providers.length; i++) {
-      const providerMetadata = this.providers[i]
-      if (providerMetadata.provider === provider) { return providerMetadata }
+    for (let providers of this.providers.values()) {
+      for (let i = 0; i < providers.length; i++) {
+        const providerMetadata = providers[i]
+        if (providerMetadata.provider === provider) { return providerMetadata }
+      }
     }
     return null
   }
@@ -179,17 +191,26 @@ export default class ProviderManager {
 
   addProvider (provider, apiVersion = '3.0.0') {
     if (this.isProviderRegistered(provider)) { return }
-    this.providers.push(new ProviderMetadata(provider, apiVersion))
+    let providerMetadata = new ProviderMetadata(provider, apiVersion)
+    let labels = providerMetadata.getLabels()
+    for (var label of labels) {
+      if (!this.providers.has(label)) {
+        this.providers.set(label, [])
+      }
+      this.providers.get(label).push(providerMetadata)
+    }
     if (provider.dispose != null) { return this.subscriptions.add(provider) }
   }
 
   removeProvider (provider) {
     if (!this.providers) { return }
-    for (let i = 0; i < this.providers.length; i++) {
-      const providerMetadata = this.providers[i]
-      if (providerMetadata.provider === provider) {
-        this.providers.splice(i, 1)
-        break
+    for (let providers of this.providers.values()) {
+      for (let i = 0; i < providers.length; i++) {
+        const providerMetadata = providers[i]
+        if (providerMetadata.provider === provider) {
+          providers.splice(i, 1)
+          break
+        }
       }
     }
     if (provider.dispose != null) {
@@ -287,13 +308,11 @@ const scopeChainForScopeDescriptor = (scopeDescriptor) => {
     const scopeChain = scopeDescriptor.getScopeChain()
     if ((scopeChain != null) && (scopeChain.replace == null)) {
       const json = JSON.stringify(scopeDescriptor)
-      console.log(scopeDescriptor, json)
       throw new Error(`01: ScopeChain is not correct type: ${type}; ${json}`)
     }
     return scopeChain
   } else {
     const json = JSON.stringify(scopeDescriptor)
-    console.log(scopeDescriptor, json)
     throw new Error(`02: ScopeChain is not correct type: ${type}; ${json}`)
   }
 }

--- a/lib/provider-metadata.js
+++ b/lib/provider-metadata.js
@@ -1,10 +1,7 @@
 'use babel'
 
 import { Selector } from 'selector-kit'
-import semver from 'semver'
 import { selectorForScopeChain, selectorsMatchScopeChain } from './scope-helpers'
-
-import { API_VERSION } from './private-symbols'
 
 export default class ProviderMetadata {
   constructor (provider, apiVersion) {
@@ -32,17 +29,6 @@ export default class ProviderMetadata {
     }
     if (providerBlacklist) {
       this.disableDefaultProviderSelectors = Selector.create(providerBlacklist)
-    }
-
-    this.enableCustomTextEditorSelector = semver.satisfies(this.provider[API_VERSION], '>=3.0.0')
-  }
-
-  matchesEditor (editor) {
-    if (this.enableCustomTextEditorSelector && (this.provider.getTextEditorSelector != null)) {
-      return atom.views.getView(editor).matches(this.provider.getTextEditorSelector())
-    } else {
-      // Backwards compatibility.
-      return atom.views.getView(editor).matches('atom-pane > .item-views > atom-text-editor')
     }
   }
 

--- a/lib/provider-metadata.js
+++ b/lib/provider-metadata.js
@@ -5,10 +5,10 @@ import { selectorForScopeChain, selectorsMatchScopeChain } from './scope-helpers
 
 export default class ProviderMetadata {
   constructor (provider, apiVersion) {
-    // TODO API: remove this when 2.0 support is removed
-
     this.provider = provider
     this.apiVersion = apiVersion
+
+    // TODO API: remove this when 2.0 support is removed
     if (this.provider.selector != null) {
       this.scopeSelectors = Selector.create(this.provider.selector)
     } else {
@@ -30,6 +30,12 @@ export default class ProviderMetadata {
     if (providerBlacklist) {
       this.disableDefaultProviderSelectors = Selector.create(providerBlacklist)
     }
+  }
+
+  getLabels () {
+    // The default label will let the provider be used for
+    // the main text editors of the workspace.
+    return this.provider.labels || ['workspace-center']
   }
 
   matchesScopeChain (scopeChain) {

--- a/lib/symbol-provider.js
+++ b/lib/symbol-provider.js
@@ -54,6 +54,7 @@ export default class SymbolProvider {
     this.buffer = null
     this.changeUpdateDelay = 300
 
+    this.labels = ['workspace-center', 'default', 'symbol-provider']
     this.scopeSelector = '*'
     this.inclusionPriority = 0
     this.suggestionPriority = 0

--- a/lib/symbol-provider.js
+++ b/lib/symbol-provider.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import _ from 'underscore-plus'
-import { CompositeDisposable, Disposable } from 'atom'
+import { CompositeDisposable } from 'atom'
 import { Selector } from 'selector-kit'
 import { UnicodeLetters } from './unicode-helpers'
 import SymbolStore from './symbol-store'
@@ -54,7 +54,6 @@ export default class SymbolProvider {
     this.buffer = null
     this.changeUpdateDelay = 300
 
-    this.textEditorSelectors = new Set(['atom-pane > .item-views > atom-text-editor'])
     this.scopeSelector = '*'
     this.inclusionPriority = 0
     this.suggestionPriority = 0
@@ -84,15 +83,6 @@ export default class SymbolProvider {
 
   dispose () {
     return this.subscriptions.dispose()
-  }
-
-  addTextEditorSelector (selector) {
-    this.textEditorSelectors.add(selector)
-    return new Disposable(() => this.textEditorSelectors.delete(selector))
-  }
-
-  getTextEditorSelector () {
-    return Array.from(this.textEditorSelectors).join(', ')
   }
 
   watchEditor (editor) {

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -173,7 +173,7 @@ describe('Provider API Legacy', () => {
 
   describe('Provider API v1.1.0', () =>
     it('registers the provider specified by {providers: [provider]}', () => {
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
 
       testProvider = {
         selector: '.source.js,.source.coffee',
@@ -182,7 +182,7 @@ describe('Provider API Legacy', () => {
 
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.1.0', {providers: [testProvider]})
 
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
     })
   )
 
@@ -225,10 +225,10 @@ describe('Provider API Legacy', () => {
 
     it('should allow registration of a provider', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -247,13 +247,13 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       triggerAutocompletion(editor, true, 'o')
 
@@ -267,10 +267,10 @@ describe('Provider API Legacy', () => {
 
     it('should dispose a provider registration correctly', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -285,37 +285,37 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
     })
 
     it('should remove a providers registration if the provider is disposed', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -331,21 +331,21 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
     })
   })
 })

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -173,7 +173,7 @@ describe('Provider API Legacy', () => {
 
   describe('Provider API v1.1.0', () =>
     it('registers the provider specified by {providers: [provider]}', () => {
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
 
       testProvider = {
         selector: '.source.js,.source.coffee',
@@ -182,7 +182,7 @@ describe('Provider API Legacy', () => {
 
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.1.0', {providers: [testProvider]})
 
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
     })
   )
 
@@ -225,10 +225,10 @@ describe('Provider API Legacy', () => {
 
     it('should allow registration of a provider', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -247,13 +247,13 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       triggerAutocompletion(editor, true, 'o')
 
@@ -267,10 +267,10 @@ describe('Provider API Legacy', () => {
 
     it('should dispose a provider registration correctly', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -285,37 +285,37 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       registration.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
     })
 
     it('should remove a providers registration if the provider is disposed', () => {
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider = {
         requestHandler (options) {
@@ -331,21 +331,21 @@ describe('Provider API Legacy', () => {
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '1.0.0', {provider: testProvider})
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(2)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[1]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.go')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
 
       testProvider.dispose()
 
       expect(autocompleteManager.providerManager.store).toBeDefined()
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee').length).toEqual(1)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.coffee')[0]).toEqual(autocompleteManager.providerManager.defaultProvider)
     })
   })
 })

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -53,9 +53,9 @@ describe('Provider API', () => {
         getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
       }
 
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', [testProvider])
-      return expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      return expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
     })
 
     it('registers the provider specified by the naked provider', () => {
@@ -64,9 +64,9 @@ describe('Provider API', () => {
         getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
       }
 
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders(editor, '.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
     })
 
     it('passes the correct parameters to getSuggestions for the version', () => {

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -4,7 +4,7 @@
 import { waitForAutocomplete, triggerAutocompletion } from './spec-helper'
 
 describe('Provider API', () => {
-  let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider] = []
+  let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
 
   beforeEach(() => {
     runs(() => {
@@ -53,9 +53,9 @@ describe('Provider API', () => {
         getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
       }
 
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', [testProvider])
-      return expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      return expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
     })
 
     it('registers the provider specified by the naked provider', () => {
@@ -64,9 +64,28 @@ describe('Provider API', () => {
         getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
       }
 
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
-      expect(autocompleteManager.providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+    })
+
+    it('registers the provider under the given list of labels, the default being [\'workspace-center\']', () => {
+      testProvider = {
+        scopeSelector: '.source.js,.source.coffee',
+        getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
+      }
+      testProvider2 = {
+        labels: ['testProvider2'],
+        scopeSelector: '.source.js,.source.coffee',
+        getSuggestions (options) { return [{text: 'ohai', replacementPrefix: 'ohai'}] }
+      }
+
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
+      expect(autocompleteManager.providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider2)
+      expect(autocompleteManager.providerManager.applicableProviders(['testProvider2'], '.source.js').length).toEqual(1)
+      expect(autocompleteManager.providerManager.applicableProviders(['testProvider2', 'workspace-center'], '.source.js').length).toEqual(3)
     })
 
     it('passes the correct parameters to getSuggestions for the version', () => {

--- a/spec/provider-manager-spec.js
+++ b/spec/provider-manager-spec.js
@@ -4,7 +4,7 @@
 import ProviderManager from '../lib/provider-manager'
 
 describe('Provider Manager', () => {
-  let [providerManager, testProvider, paneItemEditor, registration] = []
+  let [providerManager, testProvider, registration] = []
 
   beforeEach(() => {
     atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
@@ -19,11 +19,6 @@ describe('Provider Manager', () => {
       scopeSelector: '.source.js',
       dispose () {}
     }
-
-    paneItemEditor = atom.workspace.buildTextEditor()
-    let paneElement = document.createElement('atom-pane')
-    let editorElement = atom.views.getView(paneItemEditor)
-    paneElement.itemViews.appendChild(editorElement)
   })
 
   afterEach(() => {
@@ -58,8 +53,8 @@ describe('Provider Manager', () => {
     })
 
     it('registers the default provider for all scopes', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '*').length).toBe(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '*')[0]).toBe(providerManager.defaultProvider)
+      expect(providerManager.applicableProviders('*').length).toBe(1)
+      expect(providerManager.applicableProviders('*')[0]).toBe(providerManager.defaultProvider)
     })
 
     it('adds providers', () => {
@@ -154,50 +149,50 @@ describe('Provider Manager', () => {
     })
 
     it('registers a valid provider', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
 
     it('removes a registration', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
       registration.dispose()
 
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
     })
 
     it('does not create duplicate registrations for the same scope', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
 
@@ -210,13 +205,13 @@ describe('Provider Manager', () => {
         }
       }
 
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(bogusProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(bogusProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(bogusProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(bogusProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(bogusProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
     })
 
@@ -237,13 +232,13 @@ describe('Provider Manager', () => {
 
       expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
   })
@@ -252,14 +247,14 @@ describe('Provider Manager', () => {
     beforeEach(() => atom.config.set('autocomplete-plus.enableBuiltinProvider', false))
 
     it('does not register the default provider for all scopes', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '*').length).toBe(0)
+      expect(providerManager.applicableProviders('*').length).toBe(0)
       expect(providerManager.defaultProvider).toEqual(null)
       expect(providerManager.defaultProviderRegistration).toEqual(null)
     })
   })
 
   describe('when providers have been registered', () => {
-    let [testProvider1, testProvider2, testProvider3, testProvider4, testProvider5] = []
+    let [testProvider1, testProvider2, testProvider3, testProvider4] = []
 
     beforeEach(() => {
       atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
@@ -292,7 +287,6 @@ describe('Provider Manager', () => {
       }
 
       testProvider3 = {
-        getTextEditorSelector () { return 'atom-text-editor:not(.mini)' },
         scopeSelector: '*',
         getSuggestions (options) {
           return [{
@@ -314,105 +308,82 @@ describe('Provider Manager', () => {
         dispose () {}
       }
 
-      testProvider5 = {
-        getTextEditorSelector () { return 'atom-text-editor.mini' },
-        scopeSelector: '*',
-        getSuggestions (options) {
-          return [{
-            text: 'ohai5',
-            replacementPrefix: 'ohai5'
-          }]
-        },
-        dispose () {}
-      }
-
       providerManager.registerProvider(testProvider1)
       providerManager.registerProvider(testProvider2)
       providerManager.registerProvider(testProvider3)
       providerManager.registerProvider(testProvider4)
-      providerManager.registerProvider(testProvider5)
     })
 
-    it('returns providers in the correct order for the given scope chain and editor', () => {
+    it('returns providers in the correct order for the given scope chain', () => {
       let { defaultProvider } = providerManager
 
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.other')
+      let providers = providerManager.applicableProviders('.source.other')
       expect(providers).toHaveLength(2)
       expect(providers[0]).toEqual(testProvider3)
       expect(providers[1]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js')
+      providers = providerManager.applicableProviders('.source.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
       expect(providers[2]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js .comment')
+      providers = providerManager.applicableProviders('.source.js .comment')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider4)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js .variable.js')
+      providers = providerManager.applicableProviders('.source.js .variable.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js .other.js')
+      providers = providerManager.applicableProviders('.source.js .other.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
       expect(providers[2]).toEqual(defaultProvider)
-
-      let plainEditor = atom.workspace.buildTextEditor()
-      providers = providerManager.applicableProviders(plainEditor, '.source.js')
-      expect(providers).toHaveLength(1)
-      expect(providers[0]).toEqual(testProvider3)
-
-      let miniEditor = atom.workspace.buildTextEditor({mini: true})
-      providers = providerManager.applicableProviders(miniEditor, '.source.js')
-      expect(providers).toHaveLength(1)
-      expect(providers[0]).toEqual(testProvider5)
     })
 
     it('does not return providers if the scopeChain exactly matches a global blacklist item', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js .comment'])
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(0)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(0)
     })
 
     it('does not return providers if the scopeChain matches a global blacklist item with a wildcard', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js *'])
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(0)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(0)
     })
 
     it('does not return providers if the scopeChain matches a global blacklist item with a wildcard one level of depth below the current scope', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js *'])
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment .other')).toHaveLength(0)
+      expect(providerManager.applicableProviders('.source.js .comment .other')).toHaveLength(0)
     })
 
     it('does return providers if the scopeChain does not match a global blacklist item with a wildcard', () => {
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.coffee *'])
-      expect(providerManager.applicableProviders(paneItemEditor, '.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
     })
 
     it('filters a provider if the scopeChain matches a provider blacklist item', () => {
       let { defaultProvider } = providerManager
 
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.js .variable.js .other.js')
+      let providers = providerManager.applicableProviders('.source.js .variable.js .other.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js .variable.js .comment2.js')
+      providers = providerManager.applicableProviders('.source.js .variable.js .comment2.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
@@ -420,14 +391,14 @@ describe('Provider Manager', () => {
     })
 
     it('filters a provider if the scopeChain matches a provider providerblacklist item', () => {
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.js .variable.js .other.js')
+      let providers = providerManager.applicableProviders('.source.js .variable.js .other.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(providerManager.defaultProvider)
 
-      providers = providerManager.applicableProviders(paneItemEditor, '.source.js .variable.js .comment3.js')
+      providers = providerManager.applicableProviders('.source.js .variable.js .comment3.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
@@ -481,14 +452,14 @@ describe('Provider Manager', () => {
     })
 
     it('returns the default provider and higher when nothing with a higher proirity is excluding the lower', () => {
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.coffee')
+      let providers = providerManager.applicableProviders('.source.coffee')
       expect(providers).toHaveLength(2)
       expect(providers[0]).toEqual(accessoryProvider1)
       expect(providers[1]).toEqual(defaultProvider)
     })
 
     it('exclude the lower priority provider, the default, when one with a higher proirity excludes the lower', () => {
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.js')
+      let providers = providerManager.applicableProviders('.source.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(accessoryProvider2)
       expect(providers[1]).toEqual(mainProvider)
@@ -496,7 +467,7 @@ describe('Provider Manager', () => {
     })
 
     it('excludes the all lower priority providers when multiple providers of lower priority', () => {
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.js .comment')
+      let providers = providerManager.applicableProviders('.source.js .comment')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(verySpecificProvider)
       expect(providers[1]).toEqual(accessoryProvider2)
@@ -537,7 +508,7 @@ describe('Provider Manager', () => {
     })
 
     it('sorts by specificity', () => {
-      let providers = providerManager.applicableProviders(paneItemEditor, '.source.js .comment')
+      let providers = providerManager.applicableProviders('.source.js .comment')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(provider2)
       expect(providers[1]).toEqual(provider3)

--- a/spec/provider-manager-spec.js
+++ b/spec/provider-manager-spec.js
@@ -53,8 +53,8 @@ describe('Provider Manager', () => {
     })
 
     it('registers the default provider for all scopes', () => {
-      expect(providerManager.applicableProviders('*').length).toBe(1)
-      expect(providerManager.applicableProviders('*')[0]).toBe(providerManager.defaultProvider)
+      expect(providerManager.applicableProviders(['workspace-center'], '*').length).toBe(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '*')[0]).toBe(providerManager.defaultProvider)
     })
 
     it('adds providers', () => {
@@ -149,50 +149,50 @@ describe('Provider Manager', () => {
     })
 
     it('registers a valid provider', () => {
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
 
     it('removes a registration', () => {
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
       registration.dispose()
 
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
     })
 
     it('does not create duplicate registrations for the same scope', () => {
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
 
@@ -205,13 +205,13 @@ describe('Provider Manager', () => {
         }
       }
 
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(bogusProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(bogusProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(bogusProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(bogusProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(bogusProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
     })
 
@@ -232,13 +232,13 @@ describe('Provider Manager', () => {
 
       expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
 
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(1)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
-      expect(providerManager.applicableProviders('.source.js').length).toEqual(2)
-      expect(providerManager.applicableProviders('.source.js').indexOf(testProvider)).not.toBe(-1)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(2)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).not.toBe(-1)
       expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
     })
   })
@@ -247,14 +247,14 @@ describe('Provider Manager', () => {
     beforeEach(() => atom.config.set('autocomplete-plus.enableBuiltinProvider', false))
 
     it('does not register the default provider for all scopes', () => {
-      expect(providerManager.applicableProviders('*').length).toBe(0)
+      expect(providerManager.applicableProviders(['workspace-center'], '*').length).toBe(0)
       expect(providerManager.defaultProvider).toEqual(null)
       expect(providerManager.defaultProviderRegistration).toEqual(null)
     })
   })
 
   describe('when providers have been registered', () => {
-    let [testProvider1, testProvider2, testProvider3, testProvider4] = []
+    let [testProvider1, testProvider2, testProvider3, testProvider4, testProvider5] = []
 
     beforeEach(() => {
       atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
@@ -298,6 +298,7 @@ describe('Provider Manager', () => {
       }
 
       testProvider4 = {
+        labels: ['workspace-center', 'label1'],
         scopeSelector: '.source.js .comment',
         getSuggestions (options) {
           return [{
@@ -308,82 +309,103 @@ describe('Provider Manager', () => {
         dispose () {}
       }
 
+      testProvider5 = {
+        labels: ['label1'],
+        scopeSelector: '*',
+        getSuggestions (options) {
+          return [{
+            text: 'ohai5',
+            replacementPrefix: 'ohai5'
+          }]
+        },
+        dispose () {}
+      }
+
       providerManager.registerProvider(testProvider1)
       providerManager.registerProvider(testProvider2)
       providerManager.registerProvider(testProvider3)
       providerManager.registerProvider(testProvider4)
+      providerManager.registerProvider(testProvider5)
     })
 
-    it('returns providers in the correct order for the given scope chain', () => {
+    it('returns providers in the correct order for the given scope chain and labels', () => {
       let { defaultProvider } = providerManager
 
-      let providers = providerManager.applicableProviders('.source.other')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.other')
       expect(providers).toHaveLength(2)
       expect(providers[0]).toEqual(testProvider3)
       expect(providers[1]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
       expect(providers[2]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js .comment')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js .comment')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider4)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js .variable.js')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js .variable.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js .other.js')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js .other.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
       expect(providers[2]).toEqual(defaultProvider)
+
+      providers = providerManager.applicableProviders(['label1'], '.source.js .comment')
+      expect(providers).toHaveLength(2)
+      expect(providers[0]).toEqual(testProvider4)
+      expect(providers[1]).toEqual(testProvider5)
+
+      providers = providerManager.applicableProviders(['label1', 'workspace-center'], '.source.js .comment')
+      expect(providers).toHaveLength(5)
     })
 
     it('does not return providers if the scopeChain exactly matches a global blacklist item', () => {
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js .comment'])
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(0)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(0)
     })
 
     it('does not return providers if the scopeChain matches a global blacklist item with a wildcard', () => {
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js *'])
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(0)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(0)
     })
 
     it('does not return providers if the scopeChain matches a global blacklist item with a wildcard one level of depth below the current scope', () => {
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.js *'])
-      expect(providerManager.applicableProviders('.source.js .comment .other')).toHaveLength(0)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment .other')).toHaveLength(0)
     })
 
     it('does return providers if the scopeChain does not match a global blacklist item with a wildcard', () => {
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(4)
       atom.config.set('autocomplete-plus.scopeBlacklist', ['.source.coffee *'])
-      expect(providerManager.applicableProviders('.source.js .comment')).toHaveLength(4)
+      expect(providerManager.applicableProviders(['workspace-center'], '.source.js .comment')).toHaveLength(4)
     })
 
     it('filters a provider if the scopeChain matches a provider blacklist item', () => {
       let { defaultProvider } = providerManager
 
-      let providers = providerManager.applicableProviders('.source.js .variable.js .other.js')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.js .variable.js .other.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js .variable.js .comment2.js')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js .variable.js .comment2.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider1)
       expect(providers[1]).toEqual(testProvider3)
@@ -391,14 +413,14 @@ describe('Provider Manager', () => {
     })
 
     it('filters a provider if the scopeChain matches a provider providerblacklist item', () => {
-      let providers = providerManager.applicableProviders('.source.js .variable.js .other.js')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.js .variable.js .other.js')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
       expect(providers[2]).toEqual(testProvider3)
       expect(providers[3]).toEqual(providerManager.defaultProvider)
 
-      providers = providerManager.applicableProviders('.source.js .variable.js .comment3.js')
+      providers = providerManager.applicableProviders(['workspace-center'], '.source.js .variable.js .comment3.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(testProvider2)
       expect(providers[1]).toEqual(testProvider1)
@@ -452,14 +474,14 @@ describe('Provider Manager', () => {
     })
 
     it('returns the default provider and higher when nothing with a higher proirity is excluding the lower', () => {
-      let providers = providerManager.applicableProviders('.source.coffee')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.coffee')
       expect(providers).toHaveLength(2)
       expect(providers[0]).toEqual(accessoryProvider1)
       expect(providers[1]).toEqual(defaultProvider)
     })
 
     it('exclude the lower priority provider, the default, when one with a higher proirity excludes the lower', () => {
-      let providers = providerManager.applicableProviders('.source.js')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.js')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(accessoryProvider2)
       expect(providers[1]).toEqual(mainProvider)
@@ -467,7 +489,7 @@ describe('Provider Manager', () => {
     })
 
     it('excludes the all lower priority providers when multiple providers of lower priority', () => {
-      let providers = providerManager.applicableProviders('.source.js .comment')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.js .comment')
       expect(providers).toHaveLength(3)
       expect(providers[0]).toEqual(verySpecificProvider)
       expect(providers[1]).toEqual(accessoryProvider2)
@@ -508,7 +530,7 @@ describe('Provider Manager', () => {
     })
 
     it('sorts by specificity', () => {
-      let providers = providerManager.applicableProviders('.source.js .comment')
+      let providers = providerManager.applicableProviders(['workspace-center'], '.source.js .comment')
       expect(providers).toHaveLength(4)
       expect(providers[0]).toEqual(provider2)
       expect(providers[1]).toEqual(provider3)


### PR DESCRIPTION
Branched from #867.

This change introduces labels for autocompletion providers.
Editors can sign up for autocompletions from providers with a given list of labels.
If not set, the labels for a provider will default to `['workspace-center']` and the main workspace text editors will automatically receive autocompletions from providers with this label.
