### PR TITLE
Provide the watchEditor method as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ Great autocomplete depends on having great autocomplete providers. If there is n
 
 If the default `SymbolProvider` is missing useful information for the language / grammar you're working with, please take a look at the [`SymbolProvider` Config API](https://github.com/atom/autocomplete-plus/wiki/SymbolProvider-Config-API).
 
-## `AutocompleteManager` API
+## The `watchEditor` API
 
-The `AutocompleteManager` is exposed as a [provided service](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/). Its main public method is `watchEditor` which allows external editors to register for autocompletions from providers with a given set of labels.
+The `watchEditor` method on the `AutocompleteManager` object is exposed as a [provided service](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/), named `autocomplete.watchEditor`. The method allows external editors to register for autocompletions from providers with a given set of labels. Disposing the returned object will undo this request. External packages can access this service with the following code.
+
+In `package.json`:
+```
+{
+  "consumedServices": {
+    "autocomplete.watchEditor": {
+      "versions": {
+        "1.0.0": "consumeAutocompleteWatchEditor",
+      }
+    }
+  }
+}
+```
+In the main module file:
+```
+consumeAutocompleteWatchEditor(watchEditor) {
+  this.autocompleteDisposable = watchEditor(
+    this.editor, ['symbol-provider']
+  )
+}
+```

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -45,7 +45,6 @@ class AutocompleteManager {
     this.toggleActivationForBufferChange = this.toggleActivationForBufferChange.bind(this)
     this.showOrHideSuggestionListForBufferChanges = this.showOrHideSuggestionListForBufferChanges.bind(this)
     this.showOrHideSuggestionListForBufferChange = this.showOrHideSuggestionListForBufferChange.bind(this)
-    this.watchEditor = this.watchEditor.bind(this)
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,6 +22,10 @@ module.exports = {
     this.autocompleteManager = null
   },
 
+  provideWatchEditor () {
+    return this.autocompleteManager.watchEditor.bind(this.autocompleteManager)
+  },
+
   consumeSnippets (snippetsManager) {
     this.autocompleteManager.setSnippetsManager(snippetsManager)
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
     "standard": "^8.3.0",
     "temp": ">=0.7.0"
   },
+  "providedServices": {
+    "autocomplete.watchEditor": {
+      "versions": {
+        "1.0.0": "provideWatchEditor"
+      }
+    }
+  },
   "consumedServices": {
     "autocomplete.provider": {
       "versions": {


### PR DESCRIPTION
Provides a service that exposes the `AutocompleteManager` in an asynchronous way.
I'm not convinced on the naming so let me know if you have any suggestions.