### PR TITLE
Completion description style

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -44,7 +44,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   .suggestion-description-content {
     font-size: @font-size + 1px;
     font-family: @font-family;
-    max-height: 300px;
+    max-height: 33vh;
     display: block;
     overflow-y: auto;
     white-space: pre-wrap;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -44,6 +44,9 @@ autocomplete-suggestion-list.select-list.popover-list {
   .suggestion-description-content {
     font-size: @font-size + 1px;
     font-family: @font-family;
+    max-height: 300px;
+    display: block;
+    overflow-y: auto;
   }
 
   .suggestion-description-more-link {

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -47,6 +47,7 @@ autocomplete-suggestion-list.select-list.popover-list {
     max-height: 300px;
     display: block;
     overflow-y: auto;
+    white-space: pre-wrap;
   }
 
   .suggestion-description-more-link {


### PR DESCRIPTION
Completion proposals may have a lot of text in the description or rather descriptionMarkdown field. Since there is no max-height CSS style (and other related CSS attributes overflow-y etc) the height on suggestion-description the description may become very long in y direction.
I have set the `max-height` attribute for the `description-content` span and then had to set `display: block` which mean that it may just become a `div` instead of `span` perhaps.

This is the related issue: https://github.com/atom/autocomplete-plus/issues/870