### PR TITLE
Adjustments to observing text editors and listening for focus

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -154,11 +154,14 @@ export default class AutocompleteManager {
       this.updateCurrentEditor(editor, labels)
     }
 
-    let listener = (element) => this.updateCurrentEditor(editor, labels)
-    view.addEventListener('focus', listener)
+    let focusListener = (element) => this.updateCurrentEditor(editor, labels)
+    view.addEventListener('focus', focusListener)
+    let blurListener = (element) => this.hideSuggestionList()
+    view.addEventListener('blur', blurListener)
 
     let disposable = new Disposable(() => {
-      view.removeEventListener('focus', listener)
+      view.removeEventListener('focus', focusListener)
+      view.removeEventListener('blur', blurListener)
       if (this.editor === editor) {
         this.updateCurrentEditor(null)
       }
@@ -171,7 +174,7 @@ export default class AutocompleteManager {
   }
 
   handleEvents () {
-    this.subscriptions.add(atom.workspace.observeActiveTextEditor((editor) => { this.updateCurrentEditor(editor, ['workspace-center']) }))
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => { this.watchEditor(editor, ['workspace-center']) }))
 
     // Watch config values
     this.subscriptions.add(atom.config.observe('autosave.enabled', (value) => { this.autosaveEnabled = value }))


### PR DESCRIPTION
This PR changes the method of observing the pane item editors from `observeActiveTextEditor` with `updateCurrentEditor` to `observeTextEditors` with `watchEditor`.

The focus can indeed move between editors without `atom.workspace.getActiveTextEditor` changing, which is why focus listeners are necessary.

Also adds a blur listener so the autocompletions are hidden when switching focus.