### PR TITLE
Remove asynchronous construction of AutocompleteManager

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -1,20 +1,19 @@
-'use babel'
+const {Range, CompositeDisposable, Disposable} = require('atom')
+const path = require('path')
+const semver = require('semver')
+const fuzzaldrin = require('fuzzaldrin')
+const fuzzaldrinPlus = require('fuzzaldrin-plus')
 
-import { Range, CompositeDisposable, Disposable } from 'atom'
-import path from 'path'
-import semver from 'semver'
-import fuzzaldrin from 'fuzzaldrin'
-import fuzzaldrinPlus from 'fuzzaldrin-plus'
-
-import ProviderManager from './provider-manager'
-import SuggestionList from './suggestion-list'
-import { UnicodeLetters } from './unicode-helpers'
+const ProviderManager = require('./provider-manager')
+const SuggestionList = require('./suggestion-list')
+const {UnicodeLetters} = require('./unicode-helpers')
 
 // Deferred requires
 let minimatch = null
 let grim = null
 
-export default class AutocompleteManager {
+module.exports =
+class AutocompleteManager {
   constructor () {
     this.autosaveEnabled = false
     this.backspaceTriggersAutocomplete = true
@@ -47,12 +46,13 @@ export default class AutocompleteManager {
     this.showOrHideSuggestionListForBufferChanges = this.showOrHideSuggestionListForBufferChanges.bind(this)
     this.showOrHideSuggestionListForBufferChange = this.showOrHideSuggestionListForBufferChange.bind(this)
     this.watchEditor = this.watchEditor.bind(this)
-    this.subscriptions = new CompositeDisposable()
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
   }
 
   initialize () {
+    this.subscriptions = new CompositeDisposable()
+
     this.providerManager.initialize()
     this.suggestionList.initialize()
 

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -50,6 +50,11 @@ export default class AutocompleteManager {
     this.subscriptions = new CompositeDisposable()
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
+  }
+
+  initialize () {
+    this.providerManager.initialize()
+    this.suggestionList.initialize()
 
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableExtendedUnicodeSupport', enableExtendedUnicodeSupport => {
       if (enableExtendedUnicodeSupport) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,12 +3,14 @@ const AutocompleteManager = require('./autocomplete-manager')
 
 module.exports = {
   subscriptions: null,
+  autocompleteManager: new AutocompleteManager(),
 
   // Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate () {
     this.subscriptions = new CompositeDisposable()
-    this.autocompleteManager = new AutocompleteManager()
+    if (!this.autocompleteManager) this.autocompleteManager = new AutocompleteManager()
     this.subscriptions.add(this.autocompleteManager)
+    this.autocompleteManager.initialize()
   },
 
   // Public: Cleans everything up, removes all AutocompleteManager instances

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,13 +2,13 @@ const {CompositeDisposable} = require('atom')
 const AutocompleteManager = require('./autocomplete-manager')
 
 module.exports = {
-  autocompleteManager: null,
   subscriptions: null,
 
   // Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate () {
     this.subscriptions = new CompositeDisposable()
-    return this.requireAutocompleteManagerAsync()
+    this.autocompleteManager = new AutocompleteManager()
+    this.subscriptions.add(this.autocompleteManager)
   },
 
   // Public: Cleans everything up, removes all AutocompleteManager instances
@@ -20,34 +20,8 @@ module.exports = {
     this.autocompleteManager = null
   },
 
-  requireAutocompleteManagerAsync (callback) {
-    if (this.autocompleteManager) {
-      if (callback) {
-        callback(this.autocompleteManager)
-      }
-    } else {
-      setImmediate(() => {
-        const a = this.getAutocompleteManager()
-        if (a && callback) {
-          callback(a)
-        }
-      })
-    }
-  },
-
-  getAutocompleteManager () {
-    if (!this.autocompleteManager) {
-      this.autocompleteManager = new AutocompleteManager()
-      this.subscriptions.add(this.autocompleteManager)
-    }
-
-    return this.autocompleteManager
-  },
-
   consumeSnippets (snippetsManager) {
-    return this.requireAutocompleteManagerAsync((autocompleteManager) => {
-      autocompleteManager.setSnippetsManager(snippetsManager)
-    })
+    this.autocompleteManager.setSnippetsManager(snippetsManager)
   },
 
   /*
@@ -99,12 +73,10 @@ module.exports = {
     }
 
     const registrations = new CompositeDisposable()
-    this.requireAutocompleteManagerAsync((autocompleteManager) => {
-      for (let i = 0; i < providers.length; i++) {
-        const provider = providers[i]
-        registrations.add(autocompleteManager.providerManager.registerProvider(provider, apiVersion))
-      }
-    })
+    for (let i = 0; i < providers.length; i++) {
+      const provider = providers[i]
+      registrations.add(this.autocompleteManager.providerManager.registerProvider(provider, apiVersion))
+    }
     return registrations
   }
 }

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -15,7 +15,8 @@ let FuzzyProvider = require('./fuzzy-provider')
 let grim = require('grim')
 let ProviderMetadata = require('./provider-metadata')
 
-export default class ProviderManager {
+module.exports =
+class ProviderManager {
   constructor () {
     this.defaultProvider = null
     this.defaultProviderRegistration = null
@@ -31,12 +32,13 @@ export default class ProviderManager {
     this.addProvider = this.addProvider.bind(this)
     this.removeProvider = this.removeProvider.bind(this)
     this.registerProvider = this.registerProvider.bind(this)
-    this.subscriptions = new CompositeDisposable()
-    this.globalBlacklist = new CompositeDisposable()
-    this.subscriptions.add(this.globalBlacklist)
   }
 
   initialize () {
+    this.subscriptions = new CompositeDisposable()
+    this.globalBlacklist = new CompositeDisposable()
+    this.subscriptions.add(this.globalBlacklist)
+
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableBuiltinProvider', value => this.toggleDefaultProvider(value)))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.scopeBlacklist', value => this.setGlobalBlacklist(value)))
   }

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -34,6 +34,9 @@ export default class ProviderManager {
     this.subscriptions = new CompositeDisposable()
     this.globalBlacklist = new CompositeDisposable()
     this.subscriptions.add(this.globalBlacklist)
+  }
+
+  initialize () {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableBuiltinProvider', value => this.toggleDefaultProvider(value)))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.scopeBlacklist', value => this.setGlobalBlacklist(value)))
   }

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -19,6 +19,9 @@ export default class SuggestionList {
     this.activeEditor = null
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
+  }
+
+  initialize () {
     this.subscriptions.add(atom.commands.add('atom-text-editor.autocomplete-active', {
       'autocomplete-plus:confirm': this.confirmSelection,
       'autocomplete-plus:confirmIfNonDefault': this.confirmSelectionIfNonDefault,

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -1,10 +1,9 @@
-'use babel'
+const {Emitter, CompositeDisposable} = require('atom')
+const { UnicodeLetters } = require('./unicode-helpers')
+const SuggestionListElement = require('./suggestion-list-element')
 
-import { Emitter, CompositeDisposable } from 'atom'
-import { UnicodeLetters } from './unicode-helpers'
-import SuggestionListElement from './suggestion-list-element'
-
-export default class SuggestionList {
+module.exports =
+class SuggestionList {
   constructor () {
     this.wordPrefixRegex = null
     this.cancel = this.cancel.bind(this)
@@ -17,11 +16,12 @@ export default class SuggestionList {
     this.hide = this.hide.bind(this)
     this.destroyOverlay = this.destroyOverlay.bind(this)
     this.activeEditor = null
-    this.emitter = new Emitter()
-    this.subscriptions = new CompositeDisposable()
   }
 
   initialize () {
+    this.emitter = new Emitter()
+    this.subscriptions = new CompositeDisposable()
+
     this.subscriptions.add(atom.commands.add('atom-text-editor.autocomplete-active', {
       'autocomplete-plus:confirm': this.confirmSelection,
       'autocomplete-plus:confirmIfNonDefault': this.confirmSelectionIfNonDefault,

--- a/spec/provider-manager-spec.js
+++ b/spec/provider-manager-spec.js
@@ -9,6 +9,7 @@ describe('Provider Manager', () => {
   beforeEach(() => {
     atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
     providerManager = new ProviderManager()
+    providerManager.initialize()
     testProvider = {
       getSuggestions (options) {
         return [{
@@ -259,6 +260,7 @@ describe('Provider Manager', () => {
     beforeEach(() => {
       atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
       providerManager = new ProviderManager()
+      providerManager.initialize()
 
       testProvider1 = {
         scopeSelector: '.source.js',
@@ -434,6 +436,7 @@ describe('Provider Manager', () => {
     beforeEach(() => {
       atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
       providerManager = new ProviderManager()
+      providerManager.initialize()
       defaultProvider = providerManager.defaultProvider
 
       accessoryProvider1 = {
@@ -502,6 +505,7 @@ describe('Provider Manager', () => {
     beforeEach(() => {
       atom.config.set('autocomplete-plus.enableBuiltinProvider', true)
       providerManager = new ProviderManager()
+      providerManager.initialize()
 
       provider1 = {
         scopeSelector: '*',


### PR DESCRIPTION
Previously, we were deferring the construction of the `AutocompleteManager` via a `setImmediate` callback in an attempt to reduce this package's impact on startup time. Unfortunately, all this really did was **hide** this package's impact on startup time, because the `setImmediate` was still getting called before the first paint, as you can see below:

<img width="1643" alt="screen shot 2017-08-02 at 11 43 50 am" src="https://user-images.githubusercontent.com/1789/28886953-8568a408-7778-11e7-9499-09beb0be438a.png">

In #873, @wvanlint is opening up a service that allows other packages to register editors for autocomplete support. Constructing the `AutocompleteManager` asynchronously is complicating the interface of that service. This change should make that service much simpler with a synchronous API while not actually detracting from real-world startup time. We should revisit the initialization code path to see if we can actually make it faster rather than just deferring it.

This PR also changes the main module to construct the `AutocompleteManager` at eval time so that it gets baked into the startup snapshot, hence the addition of `initialize` methods that defer touching the `atom` global until package activation.