### PR TITLE
Text changes *elsewhere* in buffer should not hide selection list at cursor

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -701,12 +701,14 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       return newRange.containsPoint(lastCursorPosition)
     })
 
-    if (this.shouldActivate && changeOccurredNearLastCursor) {
-      this.cancelHideSuggestionListRequest()
-      this.requestNewSuggestions()
-    } else {
-      this.cancelNewSuggestionsRequest()
-      this.hideSuggestionList()
+    if (changeOccurredNearLastCursor) {
+      if (this.shouldActivate) {
+        this.cancelHideSuggestionListRequest()
+        this.requestNewSuggestions()
+      } else {
+        this.cancelNewSuggestionsRequest()
+        this.hideSuggestionList()
+      }
     }
 
     this.shouldActivate = false

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -585,17 +585,33 @@ describe('Autocomplete Manager', () => {
     })
 
     describe('when the character entered is not at the cursor position', () => {
-      beforeEach(() => {
+      it('does not show the suggestion list', () => {
         editor.setText('some text ok')
         editor.setCursorBufferPosition([0, 7])
-      })
 
-      it('does not show the suggestion list', () => {
         let buffer = editor.getBuffer()
         buffer.setTextInRange([[0, 0], [0, 0]], 's')
         waitForAutocomplete()
 
         runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+      })
+
+      it('does not hide the suggestion list', () => {
+        editor.setText(
+          '0\n' +
+          '1\n'
+        )
+        editor.setCursorBufferPosition([2, 0])
+        editor.insertText('2')
+        waitForAutocomplete()
+
+        runs(() => {
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          editor.setTextInBufferRange([[0, 0], [0, 0]], '*')
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          editor.setTextInBufferRange([[0, 0], [0, 0]], '\n')
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        })
       })
     })
 


### PR DESCRIPTION
Currently, if the suggestion list is displayed, and the user enters a newline or a space, we hide (i.e., dismiss) the suggestion list. That makes sense, and we want to retain that behavior. However, if a text change occurs _elsewhere_ in the buffer (e.g., automated tooling that adds semicolons at the end of each line in a JavaScript file as you're typing), that change shouldn't interfere with a human user interacting with the autocomplete suggestion list.

With the changes in this PR, we only hide the suggestion list if a text change occurs at the cursor where the human user is interacting with the autocomplete selection list.

