### PR TITLE
remove didAttach which causes SuggestionListElement to render twice

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -326,7 +326,7 @@ module.exports = class SuggestionListElement {
     if (wordContainer && wordContainer.offsetLeft) {
       this.uiProps.marginLeft = -wordContainer.offsetLeft
     }
-    if (!this.uiProps.itemHeight) {
+    if (!this.uiProps.itemHeight && this.selectedLi) {
       this.uiProps.itemHeight = this.selectedLi.offsetHeight
     }
     if (!this.uiProps.paddingHeight) {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -76,6 +76,8 @@ module.exports = class SuggestionListElement {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', useAlternateScoring => {
       this.useAlternateScoring = useAlternateScoring
     }))
+
+    process.nextTick(() => this.render())
   }
 
   // This should be unnecessary but the events we need to override

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -78,10 +78,6 @@ module.exports = class SuggestionListElement {
     }))
   }
 
-  didAttach () {
-    this.itemsChanged()
-  }
-
   // This should be unnecessary but the events we need to override
   // are handled at a level that can't be blocked by react synthetic
   // events because they are handled at the document

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -266,7 +266,6 @@ class SuggestionList {
           editorElement.classList.add('autocomplete-active')
         }
 
-        process.nextTick(() => { this.suggestionListElement.didAttach() })
         this.addBindings(editor)
       }
     }
@@ -288,7 +287,6 @@ class SuggestionList {
       }
 
       this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this.suggestionListElement, class: 'autocomplete-plus'})
-      process.nextTick(() => { this.suggestionListElement.didAttach() })
       return this.addBindings(editor)
     }
   }


### PR DESCRIPTION
When the suggestion list first appears, the the `SuggestionListElement` render method is being called twice in a single frame. I think maybe this was put in place to ensure that the suggestion list always appears with the latest suggestions. I've noticed that the suggestion list generally appears to be correct without the calls to `didAttach`. However, there is one problem I've been able to reproduce. After a reload, on the first key stroke, I get

![screen shot 2017-09-30 at 9 38 31 pm](https://user-images.githubusercontent.com/520209/31051583-13054bf2-a629-11e7-8a6e-d1ea12264dbc.png)

I'll try to see if I can resolve this without introducing a second call to `.render`. Does anyone know off the top of their head if there are any other issues with removing this?