### PR TITLE
remove use of regex in strict matching

### DIFF
--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -145,8 +145,6 @@ class SubsequenceProvider {
       editor.getBuffer().getTextInRange(cursor.getCurrentWordBufferRange())
     )
 
-    const strictMatchRegex = new RegExp(`^${prefix}`)
-
     const bufferToMaxSearchRange = (buffer) => {
       const position = this.watchedBuffers.get(buffer).getCursorBufferPosition()
       return this.clampedRange(this.maxSearchRowDelta, position.row, buffer.getEndPosition().row)
@@ -192,7 +190,9 @@ class SubsequenceProvider {
     }
 
     const isStrictIfEnabled = match => {
-      return this.strictMatching ? strictMatchRegex.exec(match.word) : true
+      return this.strictMatching
+        ? match.word.indexOf(prefix) === 0
+        : true
     }
 
     const bufferResultsToSuggestions = matchesByBuffer => {


### PR DESCRIPTION
fix https://github.com/atom/autocomplete-plus/issues/898