### PR TITLE
Move towards more efficient DOM manipulation

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -425,7 +425,7 @@ module.exports = class SuggestionListElement {
     const wordSpan = document.createElement('span')
     wordSpan.className = 'word'
     wordSpan.appendChild(
-      this.getDisplay(text, snippet, displayText, replacementPrefix)
+      this.getDisplayFrag(text, snippet, displayText, replacementPrefix)
     )
     li.querySelector('.word-container')
       .replaceChild(wordSpan, li.querySelector('.word'))
@@ -449,7 +449,7 @@ module.exports = class SuggestionListElement {
     }
   }
 
-  getDisplay (text, snippet, displayText, replacementPrefix) {
+  getDisplayFrag (text, snippet, displayText, replacementPrefix) {
     let replacementText = text
     let snippetIndices
     if (typeof displayText === 'string') {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -4,12 +4,21 @@ const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const marked = require('marked')
 
-const ItemTemplate = `<span class="icon-container"></span>
-  <span class="left-label"></span>
-  <span class="word-container">
-    <span class="word"></span>
-  </span>
-  <span class="right-label"></span>`
+const createSuggestionFrag = () => {
+  const frag = document.createDocumentFragment()
+  const children = ['icon-container', 'left-label', 'word-container', 'right-label']
+  children.forEach(c => {
+    let el = document.createElement('span')
+    el.className = c
+    if (c === 'word-container') {
+      let innerEl = document.createElement('span')
+      innerEl.className = 'word'
+      el.appendChild(innerEl)
+    }
+    frag.appendChild(el)
+  })
+  return frag
+}
 
 const ListTemplate = `<div class="suggestion-list-scroller">
     <ol class="list-group"></ol>
@@ -19,16 +28,14 @@ const ListTemplate = `<div class="suggestion-list-scroller">
     <a class="suggestion-description-more-link" href="#">More..</a>
   </div>`
 
-const IconTemplate = '<i class="icon"></i>'
-
-const DefaultSuggestionTypeIconHTML = {
-  'snippet': '<i class="icon-move-right"></i>',
-  'import': '<i class="icon-package"></i>',
-  'require': '<i class="icon-package"></i>',
-  'module': '<i class="icon-package"></i>',
-  'package': '<i class="icon-package"></i>',
-  'tag': '<i class="icon-code"></i>',
-  'attribute': '<i class="icon-tag"></i>'
+const iconTypeToClass = {
+  'snippet': 'icon-move-right',
+  'import': 'icon-package',
+  'require': 'icon-package',
+  'module': 'icon-package',
+  'package': 'icon-package',
+  'tag': 'icon-code',
+  'attribute': 'icon-tag'
 }
 
 const SnippetStart = 1
@@ -370,7 +377,7 @@ module.exports = class SuggestionListElement {
         li = this.nodePool.pop()
       } else {
         li = document.createElement('li')
-        li.innerHTML = ItemTemplate
+        li.appendChild(createSuggestionFrag())
       }
       li.dataset.index = index
       this.ol.appendChild(li)
@@ -381,22 +388,47 @@ module.exports = class SuggestionListElement {
     if (className) { this.addClassToElement(li, className) }
     if (index === this.selectedIndex) { this.selectedLi = li }
 
-    const typeIconContainer = li.querySelector('.icon-container')
-    typeIconContainer.innerHTML = ''
+    const iconContainer = document.createElement('span')
+    iconContainer.className = 'icon-container'
+    li.replaceChild(iconContainer, li.querySelector('.icon-container'))
 
-    const sanitizedType = escapeHtml(isString(type) ? type : '')
+    const sanitizedType = isString(type) ? type : ''
     const sanitizedIconHTML = isString(iconHTML) ? iconHTML : undefined
-    const defaultLetterIconHTML = sanitizedType ? `<span class="icon-letter">${sanitizedType[0]}</span>` : ''
-    const defaultIconHTML = DefaultSuggestionTypeIconHTML[sanitizedType] != null ? DefaultSuggestionTypeIconHTML[sanitizedType] : defaultLetterIconHTML
-    if ((sanitizedIconHTML || defaultIconHTML) && iconHTML !== false) {
-      typeIconContainer.innerHTML = IconTemplate
-      const typeIcon = typeIconContainer.childNodes[0]
-      typeIcon.innerHTML = sanitizedIconHTML != null ? sanitizedIconHTML : defaultIconHTML
-      if (type) { this.addClassToElement(typeIcon, type) }
+    if ((sanitizedIconHTML || sanitizedType) && iconHTML !== false) {
+      let icon = document.createElement('i')
+      icon.className = 'icon'
+
+      if (sanitizedIconHTML != null) {
+        icon.innerHTML = sanitizedIconHTML
+      } else {
+        let defaultIcon
+
+        if (iconTypeToClass[sanitizedType] != null) {
+          defaultIcon = document.createElement('i')
+          defaultIcon.className = iconTypeToClass[sanitizedType]
+        } else if (sanitizedType) {
+          defaultIcon = document.createElement('span')
+          defaultIcon.className = 'icon-letter'
+          defaultIcon.textContent = sanitizedType[0]
+        }
+
+        if (defaultIcon) {
+          icon.appendChild(defaultIcon)
+        }
+      }
+
+      if (type) { this.addClassToElement(icon, type) }
+
+      iconContainer.appendChild(icon)
     }
 
-    const wordSpan = li.querySelector('.word')
-    wordSpan.innerHTML = this.getDisplayHTML(text, snippet, displayText, replacementPrefix)
+    const wordSpan = document.createElement('span')
+    wordSpan.className = 'word'
+    wordSpan.appendChild(
+      this.getDisplay(text, snippet, displayText, replacementPrefix)
+    )
+    li.querySelector('.word-container')
+      .replaceChild(wordSpan, li.querySelector('.word'))
 
     const leftLabelSpan = li.querySelector('.left-label')
     if (leftLabelHTML != null) {
@@ -417,7 +449,7 @@ module.exports = class SuggestionListElement {
     }
   }
 
-  getDisplayHTML (text, snippet, displayText, replacementPrefix) {
+  getDisplay (text, snippet, displayText, replacementPrefix) {
     let replacementText = text
     let snippetIndices
     if (typeof displayText === 'string') {
@@ -430,21 +462,51 @@ module.exports = class SuggestionListElement {
     }
     const characterMatchIndices = this.findCharacterMatchIndices(replacementText, replacementPrefix)
 
-    let displayHTML = ''
-    for (let index = 0; index < replacementText.length; index++) {
-      if (snippetIndices && (snippetIndices[index] === SnippetStart || snippetIndices[index] === SnippetStartAndEnd)) {
-        displayHTML += '<span class="snippet-completion">'
-      }
-      if (characterMatchIndices && characterMatchIndices[index]) {
-        displayHTML += `<span class="character-match">${escapeHtml(replacementText[index])}</span>`
-      } else {
-        displayHTML += escapeHtml(replacementText[index])
-      }
-      if (snippetIndices && (snippetIndices[index] === SnippetEnd || snippetIndices[index] === SnippetStartAndEnd)) {
-        displayHTML += '</span>'
+    const appendNonMatchChars = (el, nonMatchChars) => {
+      if (nonMatchChars) {
+        el.appendChild(
+          document.createTextNode(nonMatchChars)
+        )
       }
     }
-    return displayHTML
+
+    let frag = document.createDocumentFragment()
+    let workingEl = frag
+    var nonMatchChars = ''
+    for (let index = 0; index < replacementText.length; index++) {
+      if (snippetIndices && (snippetIndices[index] === SnippetStart || snippetIndices[index] === SnippetStartAndEnd)) {
+        appendNonMatchChars(workingEl, nonMatchChars)
+        nonMatchChars = ''
+
+        let s = document.createElement('span')
+        s.className = 'snippet-completion'
+        workingEl = s
+      }
+
+      if (characterMatchIndices && characterMatchIndices[index]) {
+        appendNonMatchChars(workingEl, nonMatchChars)
+        nonMatchChars = ''
+
+        let s = document.createElement('span')
+        s.className = 'character-match'
+        s.textContent = replacementText[index]
+        workingEl.appendChild(s)
+      } else {
+        nonMatchChars += replacementText[index]
+      }
+
+      if (snippetIndices && (snippetIndices[index] === SnippetEnd || snippetIndices[index] === SnippetStartAndEnd)) {
+        appendNonMatchChars(workingEl, nonMatchChars)
+        nonMatchChars = ''
+
+        frag.appendChild(workingEl)
+        workingEl = frag
+      }
+    }
+
+    appendNonMatchChars(workingEl, nonMatchChars)
+
+    return frag
   }
 
   removeEmptySnippets (text) {
@@ -545,14 +607,4 @@ module.exports = class SuggestionListElement {
       this.parentNode.removeChild(this)
     }
   }
-}
-
-// https://github.com/component/escape-html/blob/master/index.js
-const escapeHtml = (html) => {
-  return String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
 }

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -425,7 +425,7 @@ module.exports = class SuggestionListElement {
     const wordSpan = document.createElement('span')
     wordSpan.className = 'word'
     wordSpan.appendChild(
-      this.getDisplayFrag(text, snippet, displayText, replacementPrefix)
+      this.getDisplayFragment(text, snippet, displayText, replacementPrefix)
     )
     li.querySelector('.word-container')
       .replaceChild(wordSpan, li.querySelector('.word'))
@@ -449,7 +449,7 @@ module.exports = class SuggestionListElement {
     }
   }
 
-  getDisplayFrag (text, snippet, displayText, replacementPrefix) {
+  getDisplayFragment (text, snippet, displayText, replacementPrefix) {
     let replacementText = text
     let snippetIndices
     if (typeof displayText === 'string') {

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -70,7 +70,7 @@ describe('Suggestion List Element', () => {
       let snippet
       let displayText = 'acd'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, displayText, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, displayText, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>cd')
     })
 
@@ -78,7 +78,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('')
     })
 
@@ -86,7 +86,7 @@ describe('Suggestion List Element', () => {
       let text
       let snippet = ''
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('')
     })
 
@@ -94,7 +94,7 @@ describe('Suggestion List Element', () => {
       let text
       let snippet = 'abc'
       let replacementPrefix = ''
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('abc')
     })
 
@@ -102,7 +102,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
@@ -110,7 +110,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'omg'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('abc(d, e)f')
     })
 
@@ -118,7 +118,7 @@ describe('Suggestion List Element', () => {
       let text = 'abc(d, e)f'
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
@@ -126,7 +126,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
 
@@ -134,7 +134,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'text(${1:ab}, ${2:cd})'
       let replacementPrefix = 'ta'
-      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">t</span>ext(<span class="snippet-completion"><span class="character-match">a</span>b</span>, <span class="snippet-completion">cd</span>)')
     })
 
@@ -142,7 +142,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f ${3:interface{\\}}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
@@ -150,7 +150,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:something{ok\\}}, ${3:e})f ${4:interface{\\}}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
@@ -158,7 +158,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f${3}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
   })

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -70,7 +70,7 @@ describe('Suggestion List Element', () => {
       let snippet
       let displayText = 'acd'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, displayText, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, displayText, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>cd')
     })
 
@@ -78,7 +78,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('')
     })
 
@@ -86,7 +86,7 @@ describe('Suggestion List Element', () => {
       let text
       let snippet = ''
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('')
     })
 
@@ -94,7 +94,7 @@ describe('Suggestion List Element', () => {
       let text
       let snippet = 'abc'
       let replacementPrefix = ''
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('abc')
     })
 
@@ -102,7 +102,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
@@ -110,7 +110,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'omg'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('abc(d, e)f')
     })
 
@@ -118,7 +118,7 @@ describe('Suggestion List Element', () => {
       let text = 'abc(d, e)f'
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
@@ -126,7 +126,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
 
@@ -134,7 +134,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'text(${1:ab}, ${2:cd})'
       let replacementPrefix = 'ta'
-      let html = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let html = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(html)).toBe('<span class="character-match">t</span>ext(<span class="snippet-completion"><span class="character-match">a</span>b</span>, <span class="snippet-completion">cd</span>)')
     })
 
@@ -142,7 +142,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f ${3:interface{\\}}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
@@ -150,7 +150,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:something{ok\\}}, ${3:e})f ${4:interface{\\}}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
@@ -158,7 +158,7 @@ describe('Suggestion List Element', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f${3}'
       let replacementPrefix = 'a'
-      let display = suggestionListElement.getDisplayFrag(text, snippet, null, replacementPrefix)
+      let display = suggestionListElement.getDisplayFragment(text, snippet, null, replacementPrefix)
       expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
   })

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -4,6 +4,12 @@
 
 import SuggestionListElement from '../lib/suggestion-list-element'
 
+const fragmentToHtml = fragment => {
+  const el = document.createElement('span')
+  el.appendChild(fragment.cloneNode(true))
+  return el.innerHTML
+}
+
 describe('Suggestion List Element', () => {
   let [suggestionListElement] = []
 
@@ -64,93 +70,96 @@ describe('Suggestion List Element', () => {
       let snippet
       let displayText = 'acd'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, displayText, replacementPrefix)
-      expect(html).toBe('<span class="character-match">a</span>cd')
+      let html = suggestionListElement.getDisplay(text, snippet, displayText, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>cd')
     })
 
     it('handles the empty string in the text field', () => {
       let text = ''
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('')
     })
 
     it('handles the empty string in the snippet field', () => {
       let text
       let snippet = ''
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('')
     })
 
     it('handles an empty prefix', () => {
       let text
       let snippet = 'abc'
       let replacementPrefix = ''
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('abc')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('abc')
     })
 
     it('outputs correct html when there are no snippets in the snippet field', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('<span class="character-match">a</span>bc(d, e)f')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
     it('outputs correct html when there are not character matches', () => {
       let text = ''
       let snippet = 'abc(d, e)f'
       let replacementPrefix = 'omg'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('abc(d, e)f')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('abc(d, e)f')
     })
 
     it('outputs correct html when the text field is used', () => {
       let text = 'abc(d, e)f'
       let snippet
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('<span class="character-match">a</span>bc(d, e)f')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(d, e)f')
     })
 
     it('replaces a snippet with no escaped right braces', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f'
       let replacementPrefix = 'a'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
 
     it('replaces a snippet with no escaped right braces', () => {
       let text = ''
       let snippet = 'text(${1:ab}, ${2:cd})'
       let replacementPrefix = 'ta'
-      let html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
-      expect(html).toBe('<span class="character-match">t</span>ext(<span class="snippet-completion"><span class="character-match">a</span>b</span>, <span class="snippet-completion">cd</span>)')
+      let html = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(html)).toBe('<span class="character-match">t</span>ext(<span class="snippet-completion"><span class="character-match">a</span>b</span>, <span class="snippet-completion">cd</span>)')
     })
 
     it('replaces a snippet with escaped right braces', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f ${3:interface{\\}}'
       let replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
+      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
     it('replaces a snippet with escaped multiple right braces', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:something{ok\\}}, ${3:e})f ${4:interface{\\}}'
       let replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
+      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
     })
 
     it('replaces a snippet with elements that have no text', () => {
       let text = ''
       let snippet = 'abc(${1:d}, ${2:e})f${3}'
       let replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
+      let display = suggestionListElement.getDisplay(text, snippet, null, replacementPrefix)
+      expect(fragmentToHtml(display)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
     })
   })
 


### PR DESCRIPTION
### Description of the Change
This PR moves away from setting `.innerHTML` in `.renderItem` where possible. Though, when we receive HTML via the suggestion provider API, we still have to use it. Direct DOM manipulation tends to be faster when called in a loop:
![screen shot 2017-10-03 at 11 05 19 pm](https://user-images.githubusercontent.com/520209/31206052-c26726ae-a932-11e7-9e8f-af58084600f7.png)

![screen shot 2017-10-03 at 11 05 46 pm](https://user-images.githubusercontent.com/520209/31206055-c585208e-a932-11e7-83b0-ae634c4feea9.png)

Here's an illustration of the improvement for the same autocomplete scenario before and after the changes in this PR:
![screen shot 2017-10-04 at 6 49 01 pm](https://user-images.githubusercontent.com/520209/31206386-c03cd4da-a934-11e7-9d63-b8546aa4dc7b.png)
![screen shot 2017-10-04 at 6 48 04 pm](https://user-images.githubusercontent.com/520209/31206387-c2b1acc2-a934-11e7-94a1-2e51bc5a70f5.png)


### Alternate Designs

n/a

### Benefits

This is a step towards faster rendering of autocomplete suggestions making the typing experience feel more responsive.

### Possible Drawbacks

Imperative dom manipulation can potentially be more complex than just setting `.innerHTML` in some cases.

### Applicable Issues

n/a
