### PR TITLE
Make shorter matches win when scores tie

### DIFF
--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -221,8 +221,15 @@ class SubsequenceProvider {
         }
       }
 
+      const finalSort = (a, b) => {
+        if (a.score - b.score === 0) {
+          return a.word.length - b.word.length
+        }
+        return b.score - a.score
+      }
+
       return relevantMatches
-        .sort((a, b) => b.score - a.score)
+        .sort(finalSort)
         .slice(0, this.maxSuggestions)
         .map(matchToSuggestion)
     }

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -324,7 +324,7 @@ describe('SubsequenceProvider', () => {
     })
 
   // TODO: commenting this out because I'm not sure what it's trying to test
-  //       just remove it?
+  //       just remove it? (This was brought over from the symbol provider spec.)
   //   describe('when the autocomplete.symbols changes between scopes', () => {
   //     beforeEach(() => {
   //       editor.setText(`// in-a-comment
@@ -439,11 +439,11 @@ describe('SubsequenceProvider', () => {
         waitsForPromise(() =>
           suggestionsForPrefix(provider, editor, 'ab', {raw: true}).then(suggestions => {
             expect(suggestions).toHaveLength(2)
-            expect(suggestions[0].text).toBe('abcomment')
-            expect(suggestions[0].type).toBe('comment')
-            expect(suggestions[1].text).toBe('abcd')
-            expect(suggestions[1].type).toBe('function')
-            expect(suggestions[1].rightLabel).toBe('one')
+            expect(suggestions[0].text).toBe('abcd')
+            expect(suggestions[0].type).toBe('function')
+            expect(suggestions[0].rightLabel).toBe('one')
+            expect(suggestions[1].text).toBe('abcomment')
+            expect(suggestions[1].type).toBe('comment')
           })
         )
       })
@@ -463,10 +463,10 @@ describe('SubsequenceProvider', () => {
         waitsForPromise(() =>
           suggestionsForPrefix(provider, editor, 'ab', {raw: true}).then(suggestions => {
             expect(suggestions).toHaveLength(4)
-            expect(suggestions[0].text).toBe('abcomment')
-            expect(suggestions[0].type).toBe('')
-            expect(suggestions[1].text).toBe('abcd')
-            expect(suggestions[1].type).toBe('builtin')
+            expect(suggestions[0].text).toBe('abcd')
+            expect(suggestions[0].type).toBe('builtin')
+            expect(suggestions[3].text).toBe('abcomment')
+            expect(suggestions[3].type).toBe('')
           })
         )
       })


### PR DESCRIPTION
### Description of the Change
Recently, we added a change in https://github.com/atom/superstring/pull/37/files to remove a sorting ambiguity that occurred when scores tied. This has the added benefit of returning the shorter word first when scores tie. The change in this PR applies the same sorting scheme after the results from all buffers are merged together. This should fix item#1 in https://github.com/atom/superstring/issues/36.

### Alternate Designs
n/a

### Benefits
It's more intuitive for shorter words to appear first in the suggestion list if they tie in score with neighboring matches.

### Possible Drawbacks
Maybe, this should be handled in the `.findWordsWithSubsequence` algorithm in superstring by penalizing longer words with the same number of matching characters.

### Applicable Issues
https://github.com/atom/superstring/issues/36