### PR TITLE
Defer the rendering of nonvisible suggestions

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -250,12 +250,15 @@ module.exports = class SuggestionListElement {
   }
 
   renderItems () {
+    cancelIdleCallback(this.pendingIdleCallback)
+    this.pendingIdleCallback = null
+
     let left
     this.element.style.width = null
     const items = (left = this.visibleItems()) != null ? left : []
     let longestDesc = 0
     let longestDescIndex = null
-    for (let index = 0; index < items.length; index++) {
+    for (let index = 0; index < Math.min(items.length, this.maxVisibleSuggestions); index++) {
       const item = items[index]
       this.renderItem(item, index)
       const descLength = this.descriptionLength(item)
@@ -264,6 +267,19 @@ module.exports = class SuggestionListElement {
         longestDescIndex = index
       }
     }
+
+    // Defer the rendering of suggestions that are not initially visible
+    if (items.length > this.maxVisibleSuggestions) {
+      this.pendingIdleCallback = requestIdleCallback(() => {
+        atom.views.updateDocument(() => {
+          for (let index = this.maxVisibleSuggestions; index < items.length; index++) {
+            let item = items[index]
+            this.renderItem(item, index)
+          }
+        })
+      })
+    }
+
     this.updateDescription(items[longestDescIndex])
     return this.returnItemsToPool(items.length)
   }

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -271,6 +271,8 @@ module.exports = class SuggestionListElement {
     // Defer the rendering of suggestions that are not initially visible
     if (items.length > this.maxVisibleSuggestions) {
       this.pendingIdleCallback = requestIdleCallback(() => {
+        this.pendingIdleCallback = null
+
         atom.views.updateDocument(() => {
           for (let index = this.maxVisibleSuggestions; index < items.length; index++) {
             let item = items[index]

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -250,7 +250,7 @@ module.exports = class SuggestionListElement {
   }
 
   renderItems () {
-    cancelIdleCallback(this.pendingIdleCallback)
+    global.cancelIdleCallback(this.pendingIdleCallback)
     this.pendingIdleCallback = null
 
     let left
@@ -270,7 +270,7 @@ module.exports = class SuggestionListElement {
 
     // Defer the rendering of suggestions that are not initially visible
     if (items.length > this.maxVisibleSuggestions) {
-      this.pendingIdleCallback = requestIdleCallback(() => {
+      this.pendingIdleCallback = global.requestIdleCallback(() => {
         this.pendingIdleCallback = null
 
         atom.views.updateDocument(() => {

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -616,7 +616,19 @@ describe('Autocomplete Manager', () => {
     })
 
     describe('when number of suggestions > maxVisibleSuggestions', () => {
-      beforeEach(() => atom.config.set('autocomplete-plus.maxVisibleSuggestions', 2))
+      beforeEach(() => {
+        atom.config.set('autocomplete-plus.maxVisibleSuggestions', 2)
+        global._requestIdleCallback = global.requestIdleCallback
+        // We changed the rendering logic to render nonvisible suggestions
+        // during idle time, and this is a hackity hack hack dirty hack to keep
+        // these tests working. requestIdleCallback is difficult to test because
+        // we're never idle during tests.
+        global.requestIdleCallback = cb => cb()
+      })
+
+      afterEach(() => {
+        global.requestIdleCallback = global._requestIdleCallback
+      })
 
       it('scrolls the list always showing the selected item', () => {
         triggerAutocompletion(editor, true, 'a')


### PR DESCRIPTION
### Description of the Change
Change the rendering logic to render suggestions that aren't initially visible during idle time.

### Alternate Designs
The designs mostly vary around when to do the rendering work that is being deferred. For instance, we could decide to do it on the first scroll event, but this seems like a more complicated implementation.

### Benefits
Rendering latency between keystroke and suggestion list display should be reduced since we are rendering less before painting.

### Possible Drawbacks
It's harder to test the rendering since `requestIdleCallback` callbacks never get called during testing because we are never idle. :(

### Applicable Issues
n/a