### PR TITLE
Defer rendering nonvisible suggestions until the user scrolls or selects

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -52,6 +52,7 @@ module.exports = class SuggestionListElement {
     this.subscriptions = new CompositeDisposable()
     this.element.classList.add('popover-list', 'select-list', 'autocomplete-suggestion-list')
     this.registerMouseHandling()
+    this.element.addEventListener('scroll', this.onScroll.bind(this), true)
     this.snippetParser = new SnippetParser()
     this.nodePool = []
     this.element.innerHTML = ListTemplate
@@ -107,6 +108,10 @@ module.exports = class SuggestionListElement {
         this.confirmSelection()
       }
     }
+  }
+
+  onScroll (event) {
+    atom.views.updateDocument(this.renderExtraItems.bind(this))
   }
 
   findItem (event) {
@@ -207,6 +212,11 @@ module.exports = class SuggestionListElement {
   setSelectedIndex (index) {
     this.nonDefaultIndex = true
     this.selectedIndex = index
+
+    if (index > this.maxVisibleSuggestions + 1) {
+      atom.views.updateDocument(this.renderExtraItems.bind(this))
+    }
+
     return atom.views.updateDocument(this.renderSelectedItem.bind(this))
   }
 
@@ -258,7 +268,7 @@ module.exports = class SuggestionListElement {
     const items = (left = this.visibleItems()) != null ? left : []
     let longestDesc = 0
     let longestDescIndex = null
-    for (let index = 0; index < Math.min(items.length, this.maxVisibleSuggestions); index++) {
+    for (let index = 0; index < Math.min(items.length, this.maxVisibleSuggestions + 1); index++) {
       const item = items[index]
       this.renderItem(item, index)
       const descLength = this.descriptionLength(item)
@@ -269,21 +279,24 @@ module.exports = class SuggestionListElement {
     }
 
     // Defer the rendering of suggestions that are not initially visible
-    if (items.length > this.maxVisibleSuggestions) {
-      this.pendingIdleCallback = global.requestIdleCallback(() => {
-        this.pendingIdleCallback = null
-
-        atom.views.updateDocument(() => {
-          for (let index = this.maxVisibleSuggestions; index < items.length; index++) {
-            let item = items[index]
-            this.renderItem(item, index)
-          }
-        })
-      })
+    if (items.length > this.maxVisibleSuggestions + 1) {
+      this.extraItems = items.slice(this.maxVisibleSuggestions + 1)
+    } else {
+      this.extraItems = null
     }
 
     this.updateDescription(items[longestDescIndex])
     return this.returnItemsToPool(items.length)
+  }
+
+  renderExtraItems () {
+    if (this.extraItems) {
+      this.extraItems.forEach((item, index) => {
+        this.renderItem(item, index + this.maxVisibleSuggestions + 1)
+      })
+    }
+
+    this.extraItems = null
   }
 
   returnItemsToPool (pivotIndex) {

--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -1,4 +1,3 @@
-'use babel'
 /* eslint-env jasmine */
 
 let completionDelay = 100
@@ -19,7 +18,7 @@ let triggerAutocompletion = (editor, moveCursor = true, char = 'f') => {
     editor.moveToBeginningOfLine()
   }
   editor.insertText(char)
-  exports.waitForAutocomplete()
+  module.exports.waitForAutocomplete()
 }
 
 let waitForAutocomplete = () => {
@@ -32,6 +31,22 @@ let waitForAutocomplete = () => {
         done()
       })
     })
+  })
+}
+
+let waitForDeferredSuggestions = (editorView, totalSuggestions) => {
+  waitsFor(() => {
+    return editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .suggestion-list-scroller')
+  })
+
+  runs(() => {
+    const scroller = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .suggestion-list-scroller')
+    scroller.scrollTo(0, 100)
+    scroller.scrollTo(0, 0)
+  })
+
+  waitsFor(() => {
+    return editorView.querySelectorAll('.autocomplete-plus li').length === totalSuggestions
   })
 }
 
@@ -49,4 +64,10 @@ let buildTextInputEvent = ({data, target}) => {
   return event
 }
 
-export {triggerAutocompletion, waitForAutocomplete, buildIMECompositionEvent, buildTextInputEvent}
+module.exports = {
+  triggerAutocompletion,
+  waitForAutocomplete,
+  buildIMECompositionEvent,
+  buildTextInputEvent,
+  waitForDeferredSuggestions
+}


### PR DESCRIPTION
 ### Description of the Change
This PR defers the rendering of additional suggestions until the user either scrolls the suggestion box or selects a suggestion outside of those initially visible.

### Alternate Designs
Previously, we deferred the rendering until an idle period.

### Benefits
By deferring until the user requests the additional suggestions (basically never) we save ourselves a reflow.

### Possible Drawbacks
This is slightly more difficult to test since we need to trigger a scroll event to get the rest of the suggestions to render.

### Applicable Issues
n/a