### PR TITLE
Enhancements in subsequence provider

### DIFF
--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -34,6 +34,15 @@ class SubsequenceProvider {
       }))
     })
 
+    this.subscriptions.add(this.atomConfig.observe('editor.nonWordCharacters', val => {
+      this.additionalWordCharacters = ''
+      this.possibileWordCharacters.split('').forEach(character => {
+        if (!val.includes(character)) {
+          this.additionalWordCharacters += character
+        }
+      })
+    }))
+
     this.subscriptions.add(this.atomWorkspace.observeTextEditors((e) => {
       this.watchBuffer(e)
     }))
@@ -45,7 +54,8 @@ class SubsequenceProvider {
     this.atomConfig = atom.config
     this.atomWorkspace = atom.workspace
 
-    this.additionalWordChars = '_'
+    this.additionalWordCharacters = '_'
+    this.possibileWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'
     this.enableExtendedUnicodeSupport = false
     this.maxSuggestions = 20
     this.maxResultsPerBuffer = 100
@@ -153,7 +163,7 @@ class SubsequenceProvider {
     const bufferToSubsequenceMatches = (buffer) => {
       return buffer.findWordsWithSubsequenceInRange(
         prefix,
-        this.additionalWordChars,
+        this.additionalWordCharacters,
         this.maxResultsPerBuffer,
         bufferToMaxSearchRange(buffer)
       )

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -172,11 +172,6 @@ class SubsequenceProvider {
       }
     }
 
-    const isWordUnderCursor = match => {
-      return !(wordsUnderCursors.indexOf(match.word) === -1 ||
-        match.positions.length > wordsUnderCursors.filter(word => match.word === word).length)
-    }
-
     const applyLocalityBonus = match => {
       if (match.buffer === editor.getBuffer() && match.score > 0) {
         let lastCursorRow = editor.getLastCursor().getBufferPosition().row
@@ -203,7 +198,7 @@ class SubsequenceProvider {
         for (let l = 0; l < matchesByBuffer[k].length; l++) {
           let match = matchesByBuffer[k][l]
 
-          if (isWordUnderCursor(match)) continue
+          if (wordsUnderCursors.includes(match.word)) continue
 
           if (!isStrictIfEnabled(match)) continue
 

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -118,11 +118,6 @@ describe('SubsequenceProvider', () => {
       waitsForPromise(() => {
         return suggestionsForPrefix(provider, editor, 'qu').then(sugs => {
           expect(sugs).not.toContain('qu')
-          editor.insertText(' qu')
-          waitForBufferToStopChanging()
-          return suggestionsForPrefix(provider, editor, 'qu')
-        }).then(sugs => {
-          expect(sugs).toContain('qu')
         })
       })
     })
@@ -152,22 +147,6 @@ describe('SubsequenceProvider', () => {
       waitsForPromise(() => {
         return suggestionsForPrefix(provider, editor, 'omg').then(sugs => {
           expect(sugs).not.toContain('omg')
-        })
-      })
-    })
-
-    it('returns the word under the cursor when there is a suffix and there are multiple instances of the word', done => {
-      editor.moveToBottom()
-      editor.insertText('icksort')
-      waitForBufferToStopChanging()
-      editor.moveToBeginningOfLine()
-      editor.insertText('qu')
-      waitForBufferToStopChanging()
-
-      waitsForPromise(() => {
-        return suggestionsForPrefix(provider, editor, 'qu').then(sugs => {
-          expect(sugs).not.toContain('qu')
-          expect(sugs).toContain('quicksort')
         })
       })
     })

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -266,6 +266,22 @@ describe('SubsequenceProvider', () => {
       })
     )
 
+    describe('when editor.nonWordCharacters changes', () => {
+      it('matches words that contain characters no longer included', () => {
+        editor.insertText('good-noodles ')
+
+        waitsForPromise(() =>
+          suggestionsForPrefix(provider, editor, 'good').then(sugs => {
+            expect(sugs).not.toContain('good-noodles')
+            atom.config.set('editor.nonWordCharacters', '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…')
+            return suggestionsForPrefix(provider, editor, 'good')
+          }).then(sugs => {
+            expect(sugs).toContain('good-noodles')
+          })
+        )
+      })
+    })
+
     describe('when includeCompletionsFromAllBuffers is enabled', () => {
       beforeEach(() => {
         atom.config.set('autocomplete-plus.includeCompletionsFromAllBuffers', true)


### PR DESCRIPTION
This tidies up a couple remaining issues:

 - we now respect the `edtor.nonWordCharacters` config setting
 - we never suggest the word under the cursor

fixes https://github.com/atom/autocomplete-plus/issues/901