### PR TITLE
Don't watch the same editor or buffer more than once when re-adding it to the workspace

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -47,6 +47,7 @@ class AutocompleteManager {
     this.showOrHideSuggestionListForBufferChange = this.showOrHideSuggestionListForBufferChange.bind(this)
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
+    this.watchedEditors = new WeakSet()
   }
 
   initialize () {
@@ -152,6 +153,8 @@ class AutocompleteManager {
   //
   // Returns a {Disposable} to stop watching the `editor`.
   watchEditor (editor, labels) {
+    if (this.watchedEditors.has(editor)) return
+
     let view = atom.views.getView(editor)
 
     if (view.hasFocus()) {
@@ -170,10 +173,12 @@ class AutocompleteManager {
         this.updateCurrentEditor(null)
       }
     })
+    this.watchedEditors.add(editor)
     this.subscriptions.add(disposable)
     return new Disposable(() => {
       disposable.dispose()
       this.subscriptions.remove(disposable)
+      this.watchedEditors.delete(editor)
     })
   }
 

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -76,14 +76,15 @@ class SubsequenceProvider {
   watchBuffer (editor) {
     const buffer = editor.getBuffer()
 
+    if (!this.watchedBuffers.has(buffer)) {
+      const bufferSubscriptions = new CompositeDisposable()
+      bufferSubscriptions.add(buffer.onDidDestroy(() => {
+        bufferSubscriptions.dispose()
+        this.watchedBuffers.delete(buffer)
+      }))
+    }
+
     this.watchedBuffers.set(buffer, editor)
-
-    const bufferSubscriptions = new CompositeDisposable()
-
-    bufferSubscriptions.add(buffer.onDidDestroy(() => {
-      bufferSubscriptions.dispose()
-      return this.watchedBuffers.delete(buffer)
-    }))
   }
 
   // This is kind of a hack. We throw the config suggestions in a buffer, so

--- a/lib/symbol-provider.js
+++ b/lib/symbol-provider.js
@@ -25,6 +25,7 @@ export default class SymbolProvider {
       return this.symbolStore
     }))
     this.watchedBuffers = new WeakMap()
+    this.watchedEditors = new WeakSet()
 
     this.subscriptions.add(atom.config.observe('autocomplete-plus.minimumWordLength', (minimumWordLength) => {
       this.minimumWordLength = minimumWordLength
@@ -87,6 +88,8 @@ export default class SymbolProvider {
   }
 
   watchEditor (editor) {
+    if (this.watchedEditors.has(editor)) return
+
     let bufferEditors
     const buffer = editor.getBuffer()
     const editorSubscriptions = new CompositeDisposable()
@@ -97,6 +100,7 @@ export default class SymbolProvider {
       const index = this.getWatchedEditorIndex(editor)
       const editors = this.watchedBuffers.get(editor.getBuffer())
       if (index > -1) { editors.splice(index, 1) }
+      this.watchedEditors.delete(editor)
       return editorSubscriptions.dispose()
     }))
 
@@ -123,6 +127,7 @@ export default class SymbolProvider {
       }))
 
       this.watchedBuffers.set(buffer, [editor])
+      this.watchedEditors.add(editor)
       this.buildWordListOnNextTick(editor)
     }
   }


### PR DESCRIPTION
This will prevent autocomplete-plus from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @leroix @nathansobo @jasonrudolph 