### PR TITLE
Optimize the keystroke code path

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -40,7 +40,6 @@ class AutocompleteManager {
     this.providerManager = null
     this.ready = false
     this.subscriptions = null
-    this.suggestionDelay = 50
     this.suggestionList = null
     this.suppressForClasses = []
     this.shouldDisplaySuggestions = false
@@ -637,14 +636,24 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   // Private: Gets called when the content has been modified
   requestNewSuggestions () {
     let delay = atom.config.get('autocomplete-plus.autoActivationDelay')
-    clearTimeout(this.delayTimeout)
-    if (this.suggestionList.isActive()) { delay = this.suggestionDelay }
-    this.delayTimeout = setTimeout(this.findSuggestions, delay)
+
+    if (this.delayTimeout != null) {
+      clearTimeout(this.delayTimeout)
+    }
+
+    if (delay) {
+      this.delayTimeout = setTimeout(this.findSuggestions, delay)
+    } else {
+      this.findSuggestions()
+    }
+
     this.shouldDisplaySuggestions = true
   }
 
   cancelNewSuggestionsRequest () {
-    clearTimeout(this.delayTimeout)
+    if (this.delayTimeout != null) {
+      clearTimeout(this.delayTimeout)
+    }
     this.shouldDisplaySuggestions = false
   }
 

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -8,6 +8,17 @@ const ProviderManager = require('./provider-manager')
 const SuggestionList = require('./suggestion-list')
 const {UnicodeLetters} = require('./unicode-helpers')
 
+const semverSatisfies = (function () {
+  const cache = {}
+  return (version, query) => {
+    if (cache[version + query] !== undefined) {
+      return cache[version + query]
+    }
+    const result = cache[version + query] = semver.satisfies(version, query)
+    return result
+  }
+})()
+
 // Deferred requires
 let minimatch = null
 let grim = null
@@ -240,7 +251,7 @@ class AutocompleteManager {
     const providerPromises = []
     providers.forEach(provider => {
       const apiVersion = this.providerManager.apiVersionForProvider(provider)
-      const apiIs20 = semver.satisfies(apiVersion, '>=2.0.0')
+      const apiIs20 = semverSatisfies(apiVersion, '>=2.0.0')
 
       // TODO API: remove upgrading when 1.0 support is removed
       let getSuggestions

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -35,13 +35,16 @@ class ProviderConfig {
   getSuggestionsForScopeDescriptor (scopeDescriptor) {
     this.buildConfigIfScopeChanged(scopeDescriptor)
 
-    return Object.values(this.config)
-      .reduce((suggestions, typeConfig) => {
-        if (typeConfig.suggestions) {
-          suggestions.push(typeConfig.suggestions)
+    const suggestions = []
+    for (const type of Object.keys(this.config)) {
+      if (this.config[type].suggestions) {
+        for (let k = 0; k < this.config[type].suggestions.length; k++) {
+          suggestions.push(this.config[type].suggestions[k])
         }
-        return suggestions
-      }, [])
+      }
+    }
+
+    return suggestions
   }
 
   scopeDescriptorToType (scopeDescriptor) {

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -37,8 +37,12 @@ class ProviderConfig {
     this.buildConfigIfScopeChanged(scopeDescriptor)
 
     return Object.values(this.config)
-      .map(x => x.suggestions)
-      .reduce((flat, suggestions) => suggestions ? flat.concat(suggestions) : flat, [])
+      .reduce((suggestions, typeConfig) => {
+        if (typeConfig.suggestions) {
+          suggestions.push(typeConfig.suggestions)
+        }
+        return suggestions
+      }, [])
   }
 
   scopeDescriptorToType (scopeDescriptor) {

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -1,6 +1,7 @@
 const { Selector } = require('selector-kit')
 const {selectorsMatchScopeChain} = require('./scope-helpers')
 
+module.exports =
 class ProviderConfig {
   constructor (options = {}) {
     this.atomConfig = options.atomConfig || atom.config
@@ -170,5 +171,3 @@ class ProviderConfig {
     return a.isEqual(b)
   }
 }
-
-module.exports = ProviderConfig

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -48,7 +48,7 @@ class ProviderConfig {
   scopeDescriptorToType (scopeDescriptor) {
     const scopeChain = '.' + scopeDescriptor.scopes.join(' .')
 
-    if (this.scopesToTypeMap[scopeChain]) {
+    if (this.scopesToTypeMap[scopeChain] !== undefined) {
       return this.scopesToTypeMap[scopeChain]
     }
 

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -1,6 +1,6 @@
 const _ = require('underscore-plus')
 const { Selector } = require('selector-kit')
-const {selectorsMatchScopeChain, buildScopeChainString} = require('./scope-helpers')
+const {selectorsMatchScopeChain} = require('./scope-helpers')
 
 class ProviderConfig {
   constructor (options = {}) {

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -1,4 +1,3 @@
-const _ = require('underscore-plus')
 const { Selector } = require('selector-kit')
 const {selectorsMatchScopeChain} = require('./scope-helpers')
 
@@ -138,8 +137,7 @@ class ProviderConfig {
         if (typeof suggestion === 'string') {
           sanitizedSuggestions.push({text: suggestion, type})
         } else if (typeof suggestions[0] === 'object' && ((suggestion.text != null) || (suggestion.snippet != null))) {
-          suggestion = _.clone(suggestion)
-          if (suggestion.type == null) { suggestion.type = type }
+          suggestion = Object.assign({}, {type}, suggestion)
           sanitizedSuggestions.push(suggestion)
         }
       }

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -8,6 +8,10 @@ class ProviderConfig {
 
     this.config = {}
 
+    this.scopesToTypeMap = {}
+
+    this.cachedConfigs = {}
+
     this.defaultConfig = {
       class: {
         selector: '.class.name, .inherited-class, .instance.type',
@@ -39,13 +43,18 @@ class ProviderConfig {
   }
 
   scopeDescriptorToType (scopeDescriptor) {
+    const scopeChain = '.' + scopeDescriptor.scopes.join(' .')
+
+    if (this.scopesToTypeMap[scopeChain]) {
+      return this.scopesToTypeMap[scopeChain]
+    }
+
     this.buildConfigIfScopeChanged(scopeDescriptor)
 
     let matchingType = null
     let highestTypePriority = -1
 
     const config = this.config
-    const scopeChain = buildScopeChainString(scopeDescriptor.scopes)
 
     for (const type of Object.keys(config)) {
       let {selectors, typePriority} = config[type]
@@ -57,6 +66,8 @@ class ProviderConfig {
         highestTypePriority = typePriority
       }
     }
+
+    this.scopesToTypeMap[scopeChain] = matchingType
 
     return matchingType
   }
@@ -139,7 +150,16 @@ class ProviderConfig {
   }
 
   settingsForScopeDescriptor (scopeDescriptor, keyPath) {
-    return this.atomConfig.getAll(keyPath, {scope: scopeDescriptor})
+    const cacheKey = scopeDescriptor.scopes.join(' ') + ' ' + keyPath
+    if (this.cachedConfigs[cacheKey]) {
+      return this.cachedConfigs[cacheKey]
+    }
+
+    const config = this.atomConfig.getAll(keyPath, {scope: scopeDescriptor})
+
+    this.cachedConfigs[cacheKey] = config
+
+    return config
   }
 
   safeScopeDescriptorsEqual (a, b) {

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -77,7 +77,10 @@ class ProviderConfig {
   }
 
   buildConfigIfScopeChanged (scopeDescriptor) {
-    if (!this.safeScopeDescriptorsEqual(this.currentScopeDescriptor, scopeDescriptor)) {
+    if (
+      this.currentScopeDescriptor == null ||
+      !this.currentScopeDescriptor.isEqual(scopeDescriptor)
+    ) {
       this.buildConfig(scopeDescriptor)
       this.currentScopeDescriptor = scopeDescriptor
       return this.currentScopeDescriptor
@@ -163,11 +166,5 @@ class ProviderConfig {
     this.cachedConfigs[cacheKey] = config
 
     return config
-  }
-
-  safeScopeDescriptorsEqual (a, b) {
-    if ((a == null) || (b == null)) { return false }
-
-    return a.isEqual(b)
   }
 }

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -10,8 +10,6 @@ class ProviderConfig {
 
     this.scopesToTypeMap = {}
 
-    this.cachedConfigs = {}
-
     this.defaultConfig = {
       class: {
         selector: '.class.name, .inherited-class, .instance.type',
@@ -156,14 +154,7 @@ class ProviderConfig {
   }
 
   settingsForScopeDescriptor (scopeDescriptor, keyPath) {
-    const cacheKey = scopeDescriptor.scopes.join(' ') + ' ' + keyPath
-    if (this.cachedConfigs[cacheKey]) {
-      return this.cachedConfigs[cacheKey]
-    }
-
     const config = this.atomConfig.getAll(keyPath, {scope: scopeDescriptor})
-
-    this.cachedConfigs[cacheKey] = config
 
     return config
   }

--- a/lib/scope-helpers.js
+++ b/lib/scope-helpers.js
@@ -4,20 +4,20 @@ import slick from 'atom-slick'
 
 const EscapeCharacterRegex = /[-!"#$%&'*+,/:;=?@|^~()<>{}[\]]/g
 
-const cachedMatchesBySelector = new WeakMap()
+const cachedMatchesBySelector = {}
 
 const getCachedMatch = (selector, scopeChain) => {
-  const cachedMatchesByScopeChain = cachedMatchesBySelector.get(selector)
+  const cachedMatchesByScopeChain = cachedMatchesBySelector[selector]
   if (cachedMatchesByScopeChain) {
     return cachedMatchesByScopeChain[scopeChain]
   }
 }
 
 const setCachedMatch = (selector, scopeChain, match) => {
-  let cachedMatchesByScopeChain = cachedMatchesBySelector.get(selector)
+  let cachedMatchesByScopeChain = cachedMatchesBySelector[selector]
   if (!cachedMatchesByScopeChain) {
     cachedMatchesByScopeChain = {}
-    cachedMatchesBySelector.set(selector, cachedMatchesByScopeChain)
+    cachedMatchesBySelector[selector] = cachedMatchesByScopeChain
   }
   cachedMatchesByScopeChain[scopeChain] = match
   cachedMatchesByScopeChain[scopeChain]

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -182,8 +182,6 @@ class SubsequenceProvider {
       return words
     }, {})
 
-
-
     const subsequenceMatchToType = (match) => {
       const editor = this.watchedBuffers.get(match.buffer)
       const scopeDescriptor = editor.scopeDescriptorForBufferPosition(match.positions[0])

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -105,11 +105,11 @@ class SubsequenceProvider {
       prefix,
       '(){}[] :;,$@%',
       this.maxResultsPerBuffer
-    ).then(words => {
-      for (let k = 0; k < words.length; k++) {
-        words[k].configSuggestion = suggestions[words[k].positions[0].row]
+    ).then(matches => {
+      for (let k = 0; k < matches.length; k++) {
+        matches[k].configSuggestion = suggestions[matches[k].positions[0].row]
       }
-      return words
+      return matches
     })
   }
 

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -1,6 +1,7 @@
 const { CompositeDisposable, TextBuffer } = require('atom')
 const ProviderConfig = require('./provider-config')
 
+module.exports =
 class SubsequenceProvider {
   constructor (options = {}) {
     this.defaults()
@@ -58,7 +59,7 @@ class SubsequenceProvider {
     this.possibileWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'
     this.enableExtendedUnicodeSupport = false
     this.maxSuggestions = 20
-    this.maxResultsPerBuffer = 100
+    this.maxResultsPerBuffer = 20
     this.maxSearchRowDelta = 3000
 
     this.labels = ['workspace-center', 'default', 'subsequence-provider']
@@ -90,22 +91,26 @@ class SubsequenceProvider {
   // This is kind of a hack. We throw the config suggestions in a buffer, so
   // we can use .findWordsWithSubsequence on them.
   configSuggestionsToSubsequenceMatches (suggestions, prefix) {
+    if (!suggestions || suggestions.length === 0) {
+      return Promise.resolve([])
+    }
+
     const suggestionText = suggestions
       .map(sug => sug.displayText || sug.snippet || sug.text)
       .join('\n')
 
-    this.configSuggestionsBuffer.setText(suggestionText)
-
-    const assocSuggestion = word => {
-      word.configSuggestion = suggestions[word.positions[0].row]
-      return word
-    }
+    this.configSuggestionsBuffer.buffer.setText(suggestionText)
 
     return this.configSuggestionsBuffer.findWordsWithSubsequence(
       prefix,
       '(){}[] :;,$@%',
       this.maxResultsPerBuffer
-    ).then(words => words.map(assocSuggestion))
+    ).then(words => {
+      for (let k = 0; k < words.length; k++) {
+        words[k].configSuggestion = suggestions[words[k].positions[0].row]
+      }
+      return words
+    })
   }
 
   clampedRange (maxDelta, cursorRow, maxRow) {
@@ -126,6 +131,21 @@ class SubsequenceProvider {
     }
   }
 
+  bufferToSubsequenceMatches (prefix, buffer) {
+    const position = this.watchedBuffers.get(buffer).getCursorBufferPosition()
+    const searchRange = this.clampedRange(
+      this.maxSearchRowDelta,
+      position.row,
+      buffer.getEndPosition().row
+    )
+    return buffer.findWordsWithSubsequenceInRange(
+      prefix,
+      this.additionalWordCharacters,
+      this.maxResultsPerBuffer,
+      searchRange
+    )
+  }
+
   /*
   Section: Suggesting Completions
   */
@@ -143,6 +163,10 @@ class SubsequenceProvider {
       ? Array.from(this.watchedBuffers.keys())
       : [editor.getBuffer()]
 
+    const currentEditorBuffer = editor.getBuffer()
+
+    const lastCursorRow = editor.getLastCursor().getBufferPosition().row
+
     const configSuggestions = this.providerConfig.getSuggestionsForScopeDescriptor(
       scopeDescriptor
     )
@@ -152,23 +176,13 @@ class SubsequenceProvider {
       prefix
     )
 
-    const wordsUnderCursors = editor.getCursors().map(cursor =>
-      editor.getBuffer().getTextInRange(cursor.getCurrentWordBufferRange())
-    )
+    const wordsUnderCursors = editor.getCursors().reduce((words, cursor) => {
+      const word = editor.getBuffer().getTextInRange(cursor.getCurrentWordBufferRange())
+      words[word] = true
+      return words
+    }, {})
 
-    const bufferToMaxSearchRange = (buffer) => {
-      const position = this.watchedBuffers.get(buffer).getCursorBufferPosition()
-      return this.clampedRange(this.maxSearchRowDelta, position.row, buffer.getEndPosition().row)
-    }
 
-    const bufferToSubsequenceMatches = (buffer) => {
-      return buffer.findWordsWithSubsequenceInRange(
-        prefix,
-        this.additionalWordCharacters,
-        this.maxResultsPerBuffer,
-        bufferToMaxSearchRange(buffer)
-      )
-    }
 
     const subsequenceMatchToType = (match) => {
       const editor = this.watchedBuffers.get(match.buffer)
@@ -179,41 +193,39 @@ class SubsequenceProvider {
     const matchToSuggestion = match => {
       return match.configSuggestion || {
         text: match.word,
-        type: subsequenceMatchToType(match)
+        type: subsequenceMatchToType(match),
+        characterMatchIndices: match.matchIndices
       }
     }
 
     const applyLocalityBonus = match => {
-      if (match.buffer === editor.getBuffer() && match.score > 0) {
-        let lastCursorRow = editor.getLastCursor().getBufferPosition().row
-        let distances = match
-          .positions
-          .map(pos => Math.abs(pos.row - lastCursorRow))
-        let closest = Math.min.apply(Math, distances)
+      if (match.buffer === currentEditorBuffer && match.score > 0) {
+        var closest, currentDistance
+        for (let k = 0; k < match.positions.length; k++) {
+          currentDistance = Math.abs(match.positions[k].row - lastCursorRow)
+          if (closest === undefined || currentDistance < closest) {
+            closest = currentDistance
+          }
+        }
         match.score += Math.floor(11 / (1 + 0.04 * closest))
       }
       return match
     }
 
-    const isStrictIfEnabled = match => {
-      return this.strictMatching
-        ? match.word.indexOf(prefix) === 0
-        : true
-    }
-
     const bufferResultsToSuggestions = matchesByBuffer => {
       const relevantMatches = []
       let matchedWords = {}
+      let match
 
       for (let k = 0; k < matchesByBuffer.length; k++) {
         for (let l = 0; l < matchesByBuffer[k].length; l++) {
-          let match = matchesByBuffer[k][l]
-
-          if (wordsUnderCursors.includes(match.word)) continue
-
-          if (!isStrictIfEnabled(match)) continue
+          match = matchesByBuffer[k][l]
 
           if (matchedWords[match.word]) continue
+
+          if (wordsUnderCursors[match.word]) continue
+
+          if (this.strictMatching && match.word.indexOf(prefix) !== 0) continue
 
           if (k < matchesByBuffer.length - 1) {
             match.buffer = buffers[k]
@@ -227,23 +239,21 @@ class SubsequenceProvider {
         }
       }
 
-      const finalSort = (a, b) => {
-        if (a.score - b.score === 0) {
-          return a.word.length - b.word.length
-        }
-        return b.score - a.score
-      }
-
       return relevantMatches
-        .sort(finalSort)
+        .sort(compareMatches)
         .slice(0, this.maxSuggestions)
         .map(matchToSuggestion)
     }
 
     return Promise
-      .all(buffers.map(bufferToSubsequenceMatches).concat(configMatches))
+      .all(buffers.map(this.bufferToSubsequenceMatches.bind(this, prefix)).concat(configMatches))
       .then(bufferResultsToSuggestions)
   }
 }
 
-module.exports = SubsequenceProvider
+const compareMatches = (a, b) => {
+  if (a.score - b.score === 0) {
+    return a.word.length - b.word.length
+  }
+  return b.score - a.score
+}

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -157,7 +157,7 @@ module.exports = class SuggestionListElement {
     if (this.model && this.model.items && this.model.items.length) {
       return this.render()
     } else {
-      return this.returnItemsToPool(0)
+      return atom.views.updateDocument(this.returnItemsToPool.bind(this, 0))
     }
   }
 
@@ -283,7 +283,7 @@ module.exports = class SuggestionListElement {
     }
 
     this.updateDescription(items[longestDescIndex])
-    return this.returnItemsToPool(items.length)
+    return atom.views.updateDocument(this.returnItemsToPool.bind(this, items.length))
   }
 
   renderExtraItems () {

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -398,7 +398,7 @@ module.exports = class SuggestionListElement {
     }
   }
 
-  renderItem ({iconHTML, type, snippet, text, displayText, className, replacementPrefix, leftLabel, leftLabelHTML, rightLabel, rightLabelHTML}, index) {
+  renderItem ({iconHTML, type, snippet, text, displayText, className, replacementPrefix, leftLabel, leftLabelHTML, rightLabel, rightLabelHTML, characterMatchIndices}, index) {
     let li = this.ol.childNodes[index]
     if (!li) {
       if (this.nodepool && this.nodePool.length > 0) {
@@ -453,7 +453,7 @@ module.exports = class SuggestionListElement {
     const wordSpan = document.createElement('span')
     wordSpan.className = 'word'
     wordSpan.appendChild(
-      this.getDisplayFragment(text, snippet, displayText, replacementPrefix)
+      this.getDisplayFragment(text, snippet, displayText, replacementPrefix, characterMatchIndices)
     )
     li.querySelector('.word-container')
       .replaceChild(wordSpan, li.querySelector('.word'))
@@ -477,7 +477,7 @@ module.exports = class SuggestionListElement {
     }
   }
 
-  getDisplayFragment (text, snippet, displayText, replacementPrefix) {
+  getDisplayFragment (text, snippet, displayText, replacementPrefix, characterMatchIndices) {
     let replacementText = text
     let snippetIndices
     if (typeof displayText === 'string') {
@@ -488,7 +488,15 @@ module.exports = class SuggestionListElement {
       replacementText = this.removeSnippetsFromText(snippets, replacementText)
       snippetIndices = this.findSnippetIndices(snippets)
     }
-    const characterMatchIndices = this.findCharacterMatchIndices(replacementText, replacementPrefix)
+
+    if (!characterMatchIndices) {
+      characterMatchIndices = this.findCharacterMatchIndices(replacementText, replacementPrefix)
+    } else {
+      characterMatchIndices = characterMatchIndices.reduce((matches, index) => {
+        matches[index] = true
+        return matches
+      }, {})
+    }
 
     const appendNonMatchChars = (el, nonMatchChars) => {
       if (nonMatchChars) {

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -292,7 +292,7 @@ class SuggestionList {
   }
 
   hide () {
-    this.destroyOverlay()
+    atom.views.updateDocument(this.destroyOverlay.bind(this))
     if (this.activeEditor === null) {
       return
     }

--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -104,12 +104,7 @@ describe('Async providers', () => {
 
         editor.moveToBottom()
         editor.insertText('o')
-
-        // Waiting will kick off the suggestion request
-        advanceClock(autocompleteManager.suggestionDelay * 2)
       })
-
-      waits(0)
 
       runs(() => {
         // Waiting will kick off the suggestion request

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -2297,10 +2297,10 @@ defm`
           editor.selectLeft()
 
           editor.insertText('ï')
-          advanceClock(autocompleteManager.suggestionDelay)
+          advanceClock(100)
         })
 
-        waits(autocompleteManager.suggestionDelay)
+        waits(100)
 
         runs(() => {
           expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalledWith(null)


### PR DESCRIPTION
In this PR, I

 - applied caching to hot code paths and eliminated allocations and closures where possible
 - reduced the number of matches returned per buffer from 100 to 20 in the subsequence provider
 - removed the 50ms delay for displaying suggestions (interferes with the next keystroke)
 - dealt with situations where we were rendering outside of an animation frame
 - added a `characterMatchIndices` field to suggestions in https://github.com/atom/autocomplete-plus/wiki/Provider-API#suggestions in order to remove unnecessary calls to fuzzalrin

I've tried to optimize for two things in this PR:
1) the time from key character event start to screen paint
2) the idle time between keystrokes (finishing any scripting, rendering, and painting for ac+ well ahead of the next keystroke)

In the image below, the red lines denote where the key character event starts.

![screen shot 2017-10-27 at 7 34 02 pm](https://user-images.githubusercontent.com/520209/32130075-3610f9e0-bb4e-11e7-9132-905758f5de66.png)

I'm not the fastest typer in the west, but my keystrokes can run as low as 40ms apart, and this seems to work smoothly with the changes in this PR.