### PR TITLE
Add optional getSuggestionDetailsOnSelect to provider api

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -212,7 +212,7 @@ class AutocompleteManager {
     // Handle events from suggestion list
     this.subscriptions.add(this.suggestionList.onDidConfirm((e) => { this.confirm(e) }))
     this.subscriptions.add(this.suggestionList.onDidCancel(this.hideSuggestionList))
-    this.subscriptions.add(this.suggestionList.onDidSelect(suggestion => { this.getDetailsOnFocus(suggestion) }))
+    this.subscriptions.add(this.suggestionList.onDidSelect(suggestion => { this.getDetailsOnSelect(suggestion) }))
   }
 
   handleCommands () {
@@ -529,9 +529,9 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     }
   }
 
-  getDetailsOnFocus (suggestion) {
-    if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnFocus) {
-      Promise.resolve(suggestion.provider.getSuggestionDetailsOnFocus(suggestion))
+  getDetailsOnSelect (suggestion) {
+    if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnSelect) {
+      Promise.resolve(suggestion.provider.getSuggestionDetailsOnSelect(suggestion))
         .then(detailedSuggestion => {
           this.suggestionList.replaceItem(suggestion, detailedSuggestion)
         })

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -212,6 +212,7 @@ class AutocompleteManager {
     // Handle events from suggestion list
     this.subscriptions.add(this.suggestionList.onDidConfirm((e) => { this.confirm(e) }))
     this.subscriptions.add(this.suggestionList.onDidCancel(this.hideSuggestionList))
+    this.subscriptions.add(this.suggestionList.onDidSelect(suggestion => { this.getDetailsOnFocus(suggestion) }))
   }
 
   handleCommands () {
@@ -525,6 +526,15 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       if (suggestion.onDidConfirm) {
         suggestion.onDidConfirm()
       }
+    }
+  }
+
+  getDetailsOnFocus (suggestion) {
+    if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnFocus) {
+      Promise.resolve(suggestion.provider.getSuggestionDetailsOnFocus(suggestion))
+        .then(detailedSuggestion => {
+          this.suggestionList.replaceItem(suggestion, detailedSuggestion)
+        })
     }
   }
 

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -65,6 +65,7 @@ module.exports = class SuggestionListElement {
     this.model = model
     if (this.model == null) { return }
     this.subscriptions.add(this.model.onDidChangeItems(this.itemsChanged.bind(this)))
+    this.subscriptions.add(this.model.onDidChangeItem(this.itemChanged.bind(this)))
     this.subscriptions.add(this.model.onDidSelectNext(this.moveSelectionDown.bind(this)))
     this.subscriptions.add(this.model.onDidSelectPrevious(this.moveSelectionUp.bind(this)))
     this.subscriptions.add(this.model.onDidSelectPageUp(this.moveSelectionPageUp.bind(this)))
@@ -153,6 +154,11 @@ module.exports = class SuggestionListElement {
     }
   }
 
+  itemChanged ({suggestion, index}) {
+    atom.views.updateDocument(this.renderItem.bind(this, suggestion, index))
+    atom.views.updateDocument(this.updateDescription.bind(this))
+  }
+
   itemsChanged () {
     if (this.model && this.model.items && this.model.items.length) {
       return this.render()
@@ -164,6 +170,7 @@ module.exports = class SuggestionListElement {
   render () {
     this.nonDefaultIndex = false
     this.selectedIndex = 0
+    this.model.select(this.getSelectedItem())
     if (atom.views.pollAfterNextUpdate) {
       atom.views.pollAfterNextUpdate()
     }
@@ -212,6 +219,8 @@ module.exports = class SuggestionListElement {
   setSelectedIndex (index) {
     this.nonDefaultIndex = true
     this.selectedIndex = index
+
+    this.model.select(this.getSelectedItem())
 
     if (index > this.maxVisibleSuggestions + 1) {
       atom.views.updateDocument(this.renderExtraItems.bind(this))

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -140,6 +140,10 @@ class SuggestionList {
     return this.emitter.emit('did-confirm-selection-if-non-default', event)
   }
 
+  select (suggestion) {
+    return this.emitter.emit('did-select', suggestion)
+  }
+
   selectNext () {
     return this.emitter.emit('did-select-next')
   }
@@ -180,6 +184,10 @@ class SuggestionList {
     return this.emitter.on('did-confirm', fn)
   }
 
+  onDidSelect (fn) {
+    return this.emitter.on('did-select', fn)
+  }
+
   onDidSelectNext (fn) {
     return this.emitter.on('did-select-next', fn)
   }
@@ -214,6 +222,10 @@ class SuggestionList {
 
   onDidChangeItems (fn) {
     return this.emitter.on('did-change-items', fn)
+  }
+
+  onDidChangeItem (fn) {
+    return this.emitter.on('did-change-item', fn)
   }
 
   isActive () {
@@ -325,6 +337,34 @@ class SuggestionList {
   changeItems (items) {
     this.items = items
     return this.emitter.emit('did-change-items', this.items)
+  }
+
+  replaceItem (oldSuggestion, newSuggestion) {
+    if (newSuggestion == null) {
+      return
+    }
+
+    if (this.items == null) {
+      return
+    }
+
+    let itemChanged = false
+    let itemIndex
+
+    this.items.forEach((suggestion, idx) => {
+      if (suggestion === oldSuggestion) {
+        this.items[idx] = newSuggestion
+        itemChanged = true
+        itemIndex = idx
+      }
+    })
+
+    if (itemChanged) {
+      this.emitter.emit('did-change-item', {
+        suggestion: newSuggestion,
+        index: itemIndex
+      })
+    }
   }
 
   // Public: Clean up, stop listening to events

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -190,6 +190,27 @@ describe('Provider API', () => {
       })
     })
 
+    it('it calls getSuggestionDetailsOnFocus if available and replaces suggestion', () => {
+      testProvider = {
+        scopeSelector: '.source.js, .source.coffee',
+        getSuggestions (options) {
+          return [{
+            text: 'ohai'
+          }]
+        },
+        getSuggestionDetailsOnFocus (suggestion) {
+          return Object.assign({}, suggestion, {description: 'foo'})
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
+
+      triggerAutocompletion(editor, true, 'o')
+
+      runs(() => {
+        expect(autocompleteManager.suggestionList.items[0].description).toBe('foo')
+      })
+    })
+
     describe('when the filterSuggestions option is set to true', () => {
       let getSuggestions = () => autocompleteManager.suggestionList.items.map(({text}) => ({text}))
 

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -190,7 +190,7 @@ describe('Provider API', () => {
       })
     })
 
-    it('it calls getSuggestionDetailsOnFocus if available and replaces suggestion', () => {
+    it('it calls getSuggestionDetailsOnSelect if available and replaces suggestion', () => {
       testProvider = {
         scopeSelector: '.source.js, .source.coffee',
         getSuggestions (options) {
@@ -198,7 +198,7 @@ describe('Provider API', () => {
             text: 'ohai'
           }]
         },
-        getSuggestionDetailsOnFocus (suggestion) {
+        getSuggestionDetailsOnSelect (suggestion) {
           return Object.assign({}, suggestion, {description: 'foo'})
         }
       }

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -1,8 +1,7 @@
-'use babel'
 /* eslint-env jasmine */
 /* eslint-disable no-template-curly-in-string */
-
-import SuggestionListElement from '../lib/suggestion-list-element'
+const SuggestionListElement = require('../lib/suggestion-list-element')
+const {waitForAutocomplete} = require('./spec-helper')
 
 const fragmentToHtml = fragment => {
   const el = document.createElement('span')
@@ -61,6 +60,31 @@ describe('Suggestion List Element', () => {
       suggestionListElement.renderItem(suggestion)
       expect(suggestionListElement.selectedLi.querySelector('.left-label').innerHTML).toContain('Animal&lt;Cat&gt;')
       return expect(suggestionListElement.selectedLi.querySelector('.right-label').innerHTML).toContain('Animal&lt;Dog&gt;')
+    })
+  })
+
+  describe('itemChanged', () => {
+    beforeEach(() => jasmine.attachToDOM(suggestionListElement.element))
+
+    it('updates the list item', () => {
+      const suggestion = {text: 'foo'}
+      const newSuggestion = {text: 'foo', description: 'foobar', rightLabel: 'foo'}
+      suggestionListElement.model = {items: [newSuggestion]}
+      suggestionListElement.selectedIndex = 0
+      suggestionListElement.renderItem(suggestion, 0)
+      expect(suggestionListElement.element.querySelector('.right-label').innerText).toBe('')
+
+      suggestionListElement.itemChanged({suggestion: newSuggestion, index: 0})
+
+      waitForAutocomplete()
+
+      runs(() => {
+        expect(suggestionListElement.element.querySelector('.right-label').innerText)
+          .toBe('foo')
+
+        expect(suggestionListElement.element.querySelector('.suggestion-description-content').innerText)
+          .toBe('foobar')
+      })
     })
   })
 


### PR DESCRIPTION
This adds an optional hook to the [provider api](https://github.com/atom/autocomplete-plus/wiki/Provider-API):

`.getSuggestionDetailsOnSelect(suggestion)`

This is useful in providers like the language server providers because getting additional details about the suggestion can be expensive.

It takes one of the suggestions previously received via `.getSuggestions` as its argument and returns a `Promise` of a suggestion to replace it with. The `AutocompleteManager` will call this function if it's available on the provider when the user selects or focuses a particular item in the completion list.

I'm on the fence about the name. Internally, we call this action "select", but that sounds like the user is choosing this suggestion. We call choosing the selection "confirming". It could be `.getSuggestionDetailsOnSelect`.

Here's an example of the UX this enables:
![lazy-loaded-autocomplete-content](https://user-images.githubusercontent.com/520209/32868725-b5612832-ca30-11e7-835c-4a09694023d5.gif)

Another thing I'm not sure about: should the left/right labels go away when the selection moves on?

/cc @atom/maintainers 

@damieng we can still potentially do a hook like `getSuggestionDetailsOnScroll`, but I thought I'd just do this as a first pass because it seemed like the more important one.