### PR TITLE
Fix additionalWordCharacters bug

### DIFF
--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -225,7 +225,7 @@ class SubsequenceProvider {
         for (let l = 0; l < matchesByBuffer[k].length; l++) {
           match = matchesByBuffer[k][l]
 
-          if (matchedWords[match.word]) continue
+          if (matchedWords.hasOwnProperty(match.word)) continue
 
           if (wordsUnderCursors[match.word]) continue
 

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -35,15 +35,6 @@ class SubsequenceProvider {
       }))
     })
 
-    this.subscriptions.add(this.atomConfig.observe('editor.nonWordCharacters', val => {
-      this.additionalWordCharacters = ''
-      this.possibileWordCharacters.split('').forEach(character => {
-        if (!val.includes(character)) {
-          this.additionalWordCharacters += character
-        }
-      })
-    }))
-
     this.subscriptions.add(this.atomWorkspace.observeTextEditors((e) => {
       this.watchBuffer(e)
     }))
@@ -55,8 +46,7 @@ class SubsequenceProvider {
     this.atomConfig = atom.config
     this.atomWorkspace = atom.workspace
 
-    this.additionalWordCharacters = '_'
-    this.possibileWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'
+    this.possibileWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('')
     this.enableExtendedUnicodeSupport = false
     this.maxSuggestions = 20
     this.maxResultsPerBuffer = 20
@@ -72,6 +62,20 @@ class SubsequenceProvider {
 
   dispose () {
     return this.subscriptions.dispose()
+  }
+
+  getAdditionalWordCharacters (scopeDescriptor) {
+    const nonWordCharacters = this.atomConfig.get('editor.nonWordCharacters', {scope: scopeDescriptor})
+
+    let additionalWordCharacters = ''
+
+    this.possibileWordCharacters.forEach(character => {
+      if (!nonWordCharacters.includes(character)) {
+        additionalWordCharacters += character
+      }
+    })
+
+    return additionalWordCharacters
   }
 
   watchBuffer (editor) {
@@ -131,7 +135,7 @@ class SubsequenceProvider {
     }
   }
 
-  bufferToSubsequenceMatches (prefix, buffer) {
+  bufferToSubsequenceMatches (prefix, additionalWordCharacters, buffer) {
     const position = this.watchedBuffers.get(buffer).getCursorBufferPosition()
     const searchRange = this.clampedRange(
       this.maxSearchRowDelta,
@@ -140,7 +144,7 @@ class SubsequenceProvider {
     )
     return buffer.findWordsWithSubsequenceInRange(
       prefix,
-      this.additionalWordCharacters,
+      additionalWordCharacters,
       this.maxResultsPerBuffer,
       searchRange
     )
@@ -166,6 +170,8 @@ class SubsequenceProvider {
     const currentEditorBuffer = editor.getBuffer()
 
     const lastCursorRow = editor.getLastCursor().getBufferPosition().row
+
+    const additionalWordCharacters = this.getAdditionalWordCharacters(scopeDescriptor)
 
     const configSuggestions = this.providerConfig.getSuggestionsForScopeDescriptor(
       scopeDescriptor
@@ -250,7 +256,11 @@ class SubsequenceProvider {
     }
 
     return Promise
-      .all(buffers.map(this.bufferToSubsequenceMatches.bind(this, prefix)).concat(configMatches))
+      .all(
+        buffers
+          .map(this.bufferToSubsequenceMatches.bind(this, prefix, additionalWordCharacters))
+          .concat(configMatches)
+      )
       .then(bufferResultsToSuggestions)
   }
 }


### PR DESCRIPTION
The default provider was retrieving the global `editor.nonWordCharacters` setting instead of the scoped one when calculating `additionalWordCharacters` to pass to `findWordsWithSubsequence`. 

See:
https://github.com/atom/autocomplete-plus/issues/924
https://github.com/atom/autocomplete-plus/issues/922
https://github.com/atom/autocomplete-plus/issues/920

We still need to ensure the language packages set the proper values for `editor.nonWordCharacters`.