### PR TITLE
Fix non-word character replacement

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -238,7 +238,7 @@ class AutocompleteManager {
 
     const bufferPosition = cursor.getBufferPosition()
     const scopeDescriptor = cursor.getScopeDescriptor()
-    const prefix = this.getPrefix(this.editor, bufferPosition)
+    const prefix = cursor.getCurrentWordPrefix().replace(/.* +/, ' ')
 
     return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, activatedManually})
   }
@@ -300,7 +300,15 @@ class AutocompleteManager {
         for (let i = 0; i < providerSuggestions.length; i++) {
           const suggestion = providerSuggestions[i]
           if (!suggestion.snippet && !suggestion.text) { hasEmpty = true }
-          if (suggestion.replacementPrefix == null) { suggestion.replacementPrefix = this.getDefaultReplacementPrefix(options.prefix) }
+          if (suggestion.replacementPrefix == null) {
+            const cursor = options.editor.getLastCursor()
+            const wordRegExp = cursor.wordRegExp({includeNonWordCharacters: false})
+            if (wordRegExp.test(options.prefix) === false) {
+              suggestion.replacementPrefix = ''
+            } else {
+              suggestion.replacementPrefix = options.prefix
+            }
+          }
           suggestion.provider = provider
         }
 
@@ -470,23 +478,6 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       }
     }
     return result
-  }
-
-  getPrefix (editor, bufferPosition) {
-    const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
-    const prefix = this.prefixRegex.exec(line)
-    if (!prefix || !prefix[2]) {
-      return ''
-    }
-    return prefix[2]
-  }
-
-  getDefaultReplacementPrefix (prefix) {
-    if (this.wordPrefixRegex.test(prefix)) {
-      return prefix
-    } else {
-      return ''
-    }
   }
 
   // Private: Gets called when the user successfully confirms a suggestion

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -542,10 +542,10 @@ describe('Autocomplete Manager', () => {
       })
 
       it('calls with word prefix containing a dash', () => {
-        editor.insertText('-okyea')
+        editor.insertText('_okyea')
         editor.insertText('h')
         waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc-okyeah'))
+        runs(() => expect(prefix).toBe('abc_okyeah'))
       })
 
       it('calls with space character', () => {

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -273,7 +273,11 @@ describe('SubsequenceProvider', () => {
         waitsForPromise(() =>
           suggestionsForPrefix(provider, editor, 'good').then(sugs => {
             expect(sugs).not.toContain('good-noodles')
-            atom.config.set('editor.nonWordCharacters', '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…')
+            atom.config.set(
+              'editor.nonWordCharacters',
+              '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…',
+              {scopeSelector: editor.getLastCursor().getScopeDescriptor().getScopeChain()}
+            )
             return suggestionsForPrefix(provider, editor, 'good')
           }).then(sugs => {
             expect(sugs).toContain('good-noodles')


### PR DESCRIPTION
addendum to https://github.com/atom/autocomplete-plus/pull/928

fixes https://github.com/atom/autocomplete-plus/issues/920

For instance, replacing $foo with the suggestion, $foobar, results in
$$foobar.

This PR makes autocomplete-plus now use `Cursor.getCurrentWordPrefix`
instead of using its own prefix regex. This will help keep things consistent with the `editor.nonWordCharacters` setting.