### PR TITLE
Remove editor from watchedEditors when editor is destroyed

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -179,13 +179,18 @@ class AutocompleteManager {
     this.subscriptions.add(disposable)
     return new Disposable(() => {
       disposable.dispose()
-      this.subscriptions.remove(disposable)
+      if (this.subscriptions != null) {
+        this.subscriptions.remove(disposable)
+      }
       this.watchedEditors.delete(editor)
     })
   }
 
   handleEvents () {
-    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => { this.watchEditor(editor, ['workspace-center']) }))
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      const disposable = this.watchEditor(editor, ['workspace-center'])
+      editor.onDidDestroy(() => disposable.dispose())
+    }))
 
     // Watch config values
     this.subscriptions.add(atom.config.observe('autosave.enabled', (value) => { this.autosaveEnabled = value }))


### PR DESCRIPTION
fix https://github.com/atom/autocomplete-plus/issues/935