### PR TITLE
Introduce service API version 4.0 with simplified prefix handling

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -6,6 +6,9 @@ const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const ProviderManager = require('./provider-manager')
 const SuggestionList = require('./suggestion-list')
 const {UnicodeLetters} = require('./unicode-helpers')
+const getAdditionalWordCharacters = require('./get-additional-word-characters')
+
+const wordCharacterRegexCache = new Map()
 
 // Deferred requires
 let minimatch = null
@@ -240,9 +243,10 @@ class AutocompleteManager {
 
     const bufferPosition = cursor.getBufferPosition()
     const scopeDescriptor = cursor.getScopeDescriptor()
-    const prefix = this.getPrefix(this.editor, bufferPosition)
+    const prefix = this.getPrefix(this.editor, bufferPosition, scopeDescriptor) // Passed to providers with API version >= 4.0.0
+    const legacyPrefix = this.getLegacyPrefix(this.editor, bufferPosition) // Passed to providers with API version < 4.0.0
 
-    return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, activatedManually})
+    return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, legacyPrefix, activatedManually})
   }
 
   getSuggestionsFromProviders (options) {
@@ -255,24 +259,27 @@ class AutocompleteManager {
 
       let getSuggestions
       let upgradedOptions
-      switch (apiVersion) {
-        case 1:
-          getSuggestions = provider.requestHandler.bind(provider)
-          upgradedOptions = {
-            editor: options.editor,
-            prefix: options.prefix,
-            bufferPosition: options.bufferPosition,
-            position: options.bufferPosition,
-            scope: options.scopeDescriptor,
-            scopeChain: options.scopeDescriptor.getScopeChain(),
-            buffer: options.editor.getBuffer(),
-            cursor: options.editor.getLastCursor()
-          }
-          break;
-        case 2:
-        case 3:
-          getSuggestions = provider.getSuggestions.bind(provider)
+
+      if (apiVersion === 1) {
+        getSuggestions = provider.requestHandler.bind(provider)
+        upgradedOptions = {
+          editor: options.editor,
+          prefix: options.prefix,
+          bufferPosition: options.bufferPosition,
+          position: options.bufferPosition,
+          scope: options.scopeDescriptor,
+          scopeChain: options.scopeDescriptor.getScopeChain(),
+          buffer: options.editor.getBuffer(),
+          cursor: options.editor.getLastCursor()
+        }
+      } else {
+        getSuggestions = provider.getSuggestions.bind(provider)
+        if (apiVersion < 4) {
+          upgradedOptions = Object.assign({}, options)
+          upgradedOptions.prefix = options.legacyPrefix
+        } else {
           upgradedOptions = options
+        }
       }
 
       return providerPromises.push(Promise.resolve(getSuggestions(upgradedOptions)).then(providerSuggestions => {
@@ -475,7 +482,36 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return result
   }
 
-  getPrefix (editor, bufferPosition) {
+  getPrefix (editor, position, scopeDescriptor) {
+    const wordCharacterRegex = this.getWordCharacterRegex(scopeDescriptor)
+    console.log(wordCharacterRegex)
+    const line = editor.getBuffer().getTextInRange([[position.row, 0], position])
+
+
+    let startColumn = position.column
+    while (startColumn > 0) {
+      let prevChar = line[startColumn - 1]
+      if (wordCharacterRegex.test(prevChar)) {
+        startColumn--
+      } else {
+        break
+      }
+    }
+    return line.slice(startColumn)
+  }
+
+  getWordCharacterRegex (scopeDescriptor) {
+    const additionalWordChars = getAdditionalWordCharacters(scopeDescriptor)
+    let regex = wordCharacterRegexCache.get(additionalWordChars)
+
+    if (!regex) {
+      regex = new RegExp(`[${UnicodeLetters}${additionalWordChars.replace(']', '\\]')}]`)
+      wordCharacterRegexCache.set(additionalWordChars, regex)
+    }
+    return regex
+  }
+
+  getLegacyPrefix (editor, bufferPosition) {
     const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     const prefix = this.prefixRegex.exec(line)
     if (!prefix || !prefix[2]) {

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -1,23 +1,11 @@
 const {CompositeDisposable, Disposable} = require('atom')
 const path = require('path')
-const semver = require('semver')
 const fuzzaldrin = require('fuzzaldrin')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 
 const ProviderManager = require('./provider-manager')
 const SuggestionList = require('./suggestion-list')
 const {UnicodeLetters} = require('./unicode-helpers')
-
-const semverSatisfies = (function () {
-  const cache = {}
-  return (version, query) => {
-    if (cache[version + query] !== undefined) {
-      return cache[version + query]
-    }
-    const result = cache[version + query] = semver.satisfies(version, query)
-    return result
-  }
-})()
 
 // Deferred requires
 let minimatch = null
@@ -264,26 +252,27 @@ class AutocompleteManager {
     const providerPromises = []
     providers.forEach(provider => {
       const apiVersion = this.providerManager.apiVersionForProvider(provider)
-      const apiIs20 = semverSatisfies(apiVersion, '>=2.0.0')
 
-      // TODO API: remove upgrading when 1.0 support is removed
       let getSuggestions
       let upgradedOptions
-      if (apiIs20) {
-        getSuggestions = provider.getSuggestions.bind(provider)
-        upgradedOptions = options
-      } else {
-        getSuggestions = provider.requestHandler.bind(provider)
-        upgradedOptions = {
-          editor: options.editor,
-          prefix: options.prefix,
-          bufferPosition: options.bufferPosition,
-          position: options.bufferPosition,
-          scope: options.scopeDescriptor,
-          scopeChain: options.scopeDescriptor.getScopeChain(),
-          buffer: options.editor.getBuffer(),
-          cursor: options.editor.getLastCursor()
-        }
+      switch (apiVersion) {
+        case 1:
+          getSuggestions = provider.requestHandler.bind(provider)
+          upgradedOptions = {
+            editor: options.editor,
+            prefix: options.prefix,
+            bufferPosition: options.bufferPosition,
+            position: options.bufferPosition,
+            scope: options.scopeDescriptor,
+            scopeChain: options.scopeDescriptor.getScopeChain(),
+            buffer: options.editor.getBuffer(),
+            cursor: options.editor.getLastCursor()
+          }
+          break;
+        case 2:
+        case 3:
+          getSuggestions = provider.getSuggestions.bind(provider)
+          upgradedOptions = options
       }
 
       return providerPromises.push(Promise.resolve(getSuggestions(upgradedOptions)).then(providerSuggestions => {
@@ -291,11 +280,11 @@ class AutocompleteManager {
 
         // TODO API: remove upgrading when 1.0 support is removed
         let hasDeprecations = false
-        if (apiIs20 && providerSuggestions.length) {
+        if (apiVersion > 1 && providerSuggestions.length) {
           hasDeprecations = this.deprecateForSuggestion(provider, providerSuggestions[0])
         }
 
-        if (hasDeprecations || !apiIs20) {
+        if (hasDeprecations || apiVersion === 1) {
           providerSuggestions = providerSuggestions.map((suggestion) => {
             const newSuggestion = {
               text: suggestion.text != null ? suggestion.text : suggestion.word,
@@ -510,7 +499,6 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     if ((this.editor == null) || (suggestion == null) || !!this.disposed) { return }
 
     const apiVersion = this.providerManager.apiVersionForProvider(suggestion.provider)
-    const apiIs20 = semver.satisfies(apiVersion, '>=2.0.0')
     const triggerPosition = this.editor.getLastCursor().getBufferPosition()
 
     // TODO API: Remove as this is no longer used
@@ -531,8 +519,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
 
     this.replaceTextWithMatch(suggestion)
 
-    // TODO API: Remove when we remove the 1.0 API
-    if (apiIs20) {
+    if (apiVersion > 1) {
       if (suggestion.provider && suggestion.provider.onDidInsertSuggestion) {
         suggestion.provider.onDidInsertSuggestion({editor: this.editor, suggestion, triggerPosition})
       }

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -252,7 +252,7 @@ class AutocompleteManager {
 
     const bufferPosition = cursor.getBufferPosition()
     const scopeDescriptor = cursor.getScopeDescriptor()
-    const prefix = cursor.getCurrentWordPrefix().replace(/.* +/, ' ')
+    const prefix = this.getPrefix(this.editor, bufferPosition)
 
     return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, activatedManually})
   }
@@ -314,15 +314,7 @@ class AutocompleteManager {
         for (let i = 0; i < providerSuggestions.length; i++) {
           const suggestion = providerSuggestions[i]
           if (!suggestion.snippet && !suggestion.text) { hasEmpty = true }
-          if (suggestion.replacementPrefix == null) {
-            const cursor = options.editor.getLastCursor()
-            const wordRegExp = cursor.wordRegExp({includeNonWordCharacters: false})
-            if (wordRegExp.test(options.prefix) === false) {
-              suggestion.replacementPrefix = ''
-            } else {
-              suggestion.replacementPrefix = options.prefix
-            }
-          }
+          if (suggestion.replacementPrefix == null) { suggestion.replacementPrefix = this.getDefaultReplacementPrefix(options.prefix) }
           suggestion.provider = provider
         }
 
@@ -492,6 +484,23 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       }
     }
     return result
+  }
+
+  getPrefix (editor, bufferPosition) {
+    const line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    const prefix = this.prefixRegex.exec(line)
+    if (!prefix || !prefix[2]) {
+      return ''
+    }
+    return prefix[2]
+  }
+
+  getDefaultReplacementPrefix (prefix) {
+    if (this.wordPrefixRegex.test(prefix)) {
+      return prefix
+    } else {
+      return ''
+    }
   }
 
   // Private: Gets called when the user successfully confirms a suggestion

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -278,7 +278,8 @@ class AutocompleteManager {
           upgradedOptions = Object.assign({}, options)
           upgradedOptions.prefix = options.legacyPrefix
         } else {
-          upgradedOptions = options
+          upgradedOptions = Object.assign({}, options)
+          delete upgradedOptions.legacyPrefix
         }
       }
 

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -310,7 +310,13 @@ class AutocompleteManager {
         for (let i = 0; i < providerSuggestions.length; i++) {
           const suggestion = providerSuggestions[i]
           if (!suggestion.snippet && !suggestion.text) { hasEmpty = true }
-          if (suggestion.replacementPrefix == null) { suggestion.replacementPrefix = this.getDefaultReplacementPrefix(options.prefix) }
+          if (suggestion.replacementPrefix == null) {
+            if (apiVersion < 4) {
+              suggestion.replacementPrefix = this.wordPrefixRegex.test(options.prefix) ? options.prefix : ''
+            } else {
+              suggestion.replacementPrefix = options.prefix
+            }
+          }
           suggestion.provider = provider
         }
 
@@ -484,9 +490,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
 
   getPrefix (editor, position, scopeDescriptor) {
     const wordCharacterRegex = this.getWordCharacterRegex(scopeDescriptor)
-    console.log(wordCharacterRegex)
     const line = editor.getBuffer().getTextInRange([[position.row, 0], position])
-
 
     let startColumn = position.column
     while (startColumn > 0) {
@@ -518,14 +522,6 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       return ''
     }
     return prefix[2]
-  }
-
-  getDefaultReplacementPrefix (prefix) {
-    if (this.wordPrefixRegex.test(prefix)) {
-      return prefix
-    } else {
-      return ''
-    }
   }
 
   // Private: Gets called when the user successfully confirms a suggestion

--- a/lib/get-additional-word-characters.js
+++ b/lib/get-additional-word-characters.js
@@ -1,0 +1,14 @@
+const POSSIBLE_WORD_CHARACTERS = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('')
+
+module.exports =
+function getAdditionalWordCharacters (scopeDescriptor) {
+  const nonWordCharacters = atom.config.get('editor.nonWordCharacters', {scope: scopeDescriptor})
+  let additionalWordCharacters = ''
+  POSSIBLE_WORD_CHARACTERS.forEach(character => {
+    if (!nonWordCharacters.includes(character)) {
+      additionalWordCharacters += character
+    }
+  })
+
+  return additionalWordCharacters
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,7 +40,6 @@ module.exports = {
     if (!service || !service.provider) {
       return
     }
-    // TODO API: Deprecate, tell them to upgrade to 3.0
     return this.consumeProvider([service.provider], 1)
   },
 
@@ -50,21 +49,22 @@ module.exports = {
     if (!service || !service.providers) {
       return
     }
-    // TODO API: Deprecate, tell them to upgrade to 3.0
     return this.consumeProvider(service.providers, 1)
   },
 
   // 2.0.0 API
-  // providers - either a provider or a list of providers
   consumeProvider_2 (providers) {
-    // TODO API: Deprecate, tell them to upgrade to 3.0
     return this.consumeProvider(providers, 2)
   },
 
   // 3.0.0 API
-  // providers - either a provider or a list of providers
   consumeProvider_3 (providers) {
     return this.consumeProvider(providers, 3)
+  },
+
+  // 4.0.0 API – Simplifies prefix computation
+  consumeProvider_4 (providers) {
+    return this.consumeProvider(providers, 4)
   },
 
   consumeProvider (providers, apiVersion = 3) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,12 +36,12 @@ module.exports = {
 
   // 1.0.0 API
   // service - {provider: provider1}
-  consumeProvider_1_0 (service) {
+  consumeProvider_1 (service) {
     if (!service || !service.provider) {
       return
     }
     // TODO API: Deprecate, tell them to upgrade to 3.0
-    return this.consumeProvider([service.provider], '1.0.0')
+    return this.consumeProvider([service.provider], 1)
   },
 
   // 1.1.0 API
@@ -51,23 +51,23 @@ module.exports = {
       return
     }
     // TODO API: Deprecate, tell them to upgrade to 3.0
-    return this.consumeProvider(service.providers, '1.1.0')
+    return this.consumeProvider(service.providers, 1)
   },
 
   // 2.0.0 API
   // providers - either a provider or a list of providers
-  consumeProvider_2_0 (providers) {
+  consumeProvider_2 (providers) {
     // TODO API: Deprecate, tell them to upgrade to 3.0
-    return this.consumeProvider(providers, '2.0.0')
+    return this.consumeProvider(providers, 2)
   },
 
   // 3.0.0 API
   // providers - either a provider or a list of providers
-  consumeProvider_3_0 (providers) {
-    return this.consumeProvider(providers, '3.0.0')
+  consumeProvider_3 (providers) {
+    return this.consumeProvider(providers, 3)
   },
 
-  consumeProvider (providers, apiVersion = '3.0.0') {
+  consumeProvider (providers, apiVersion = 3) {
     if (!providers) {
       return
     }

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -2,7 +2,6 @@
 
 import { CompositeDisposable, Disposable } from 'atom'
 import { isFunction, isString } from './type-helpers'
-import semver from 'semver'
 import { Selector } from 'selector-kit'
 import stableSort from 'stable'
 
@@ -163,8 +162,7 @@ class ProviderManager {
   }
 
   isValidProvider (provider, apiVersion) {
-    // TODO API: Check based on the apiVersion
-    if (semver.satisfies(apiVersion, '>=2.0.0')) {
+    if (apiVersion >= 2) {
       return (provider != null) &&
       isFunction(provider.getSuggestions) &&
       ((isString(provider.selector) && !!provider.selector.length) ||
@@ -194,7 +192,7 @@ class ProviderManager {
     return (this.metadataForProvider(provider) != null)
   }
 
-  addProvider (provider, apiVersion = '3.0.0') {
+  addProvider (provider, apiVersion = 3) {
     if (this.isProviderRegistered(provider)) { return }
     let providerMetadata = new ProviderMetadata(provider, apiVersion)
     let labels = providerMetadata.getLabels()
@@ -225,53 +223,51 @@ class ProviderManager {
     }
   }
 
-  registerProvider (provider, apiVersion = '3.0.0') {
+  registerProvider (provider, apiVersion = 3) {
     if (provider == null) { return }
 
     provider[API_VERSION] = apiVersion
 
-    const apiIs200 = semver.satisfies(apiVersion, '>=2.0.0')
-    const apiIs300 = semver.satisfies(apiVersion, '>=3.0.0')
+    switch (apiVersion) {
+      case 2:
+        if ((provider.id != null) && provider !== this.defaultProvider) {
+          grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
+  contains an \`id\` property.
+  An \`id\` attribute on your provider is no longer necessary.
+  See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
+          )
+        }
+        if (provider.requestHandler != null) {
+          if (typeof grim === 'undefined' || grim === null) { grim = require('grim') }
+          grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
+  contains a \`requestHandler\` property.
+  \`requestHandler\` has been renamed to \`getSuggestions\`.
+  See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
+          )
+        }
+        if (provider.blacklist != null) {
+          if (typeof grim === 'undefined' || grim === null) { grim = require('grim') }
+          grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
+  contains a \`blacklist\` property.
+  \`blacklist\` has been renamed to \`disableForScopeSelector\`.
+  See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
+          )
+        }
+        break;
+      case 3:
+        if (provider.selector != null) {
+          throw new Error(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
+  specifies \`selector\` instead of the \`scopeSelector\` attribute.
+  See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
+        }
 
-    if (apiIs200) {
-      if ((provider.id != null) && provider !== this.defaultProvider) {
-        grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
-contains an \`id\` property.
-An \`id\` attribute on your provider is no longer necessary.
-See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
-        )
-      }
-      if (provider.requestHandler != null) {
-        if (typeof grim === 'undefined' || grim === null) { grim = require('grim') }
-        grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
-contains a \`requestHandler\` property.
-\`requestHandler\` has been renamed to \`getSuggestions\`.
-See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
-        )
-      }
-      if (provider.blacklist != null) {
-        if (typeof grim === 'undefined' || grim === null) { grim = require('grim') }
-        grim.deprecate(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
-contains a \`blacklist\` property.
-\`blacklist\` has been renamed to \`disableForScopeSelector\`.
-See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
-        )
-      }
-    }
-
-    if (apiIs300) {
-      if (provider.selector != null) {
-        throw new Error(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
-specifies \`selector\` instead of the \`scopeSelector\` attribute.
-See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
-      }
-
-      if (provider.disableForSelector != null) {
-        throw new Error(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
-specifies \`disableForSelector\` instead of the \`disableForScopeSelector\`
-attribute.
-See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
-      }
+        if (provider.disableForSelector != null) {
+          throw new Error(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
+  specifies \`disableForSelector\` instead of the \`disableForScopeSelector\`
+  attribute.
+  See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
+        }
+        break;
     }
 
     if (!this.isValidProvider(provider, apiVersion)) {

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -253,7 +253,7 @@ class ProviderManager {
   See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
           )
         }
-        break;
+        break
       case 3:
         if (provider.selector != null) {
           throw new Error(`Autocomplete provider '${provider.constructor.name}(${provider.id})'
@@ -267,7 +267,7 @@ class ProviderManager {
   attribute.
   See https://github.com/atom/autocomplete-plus/wiki/Provider-API.`)
         }
-        break;
+        break
     }
 
     if (!this.isValidProvider(provider, apiVersion)) {

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -141,7 +141,7 @@ class ProviderManager {
       } else {
         this.defaultProvider = new SubsequenceProvider()
       }
-      this.defaultProviderRegistration = this.registerProvider(this.defaultProvider)
+      this.defaultProviderRegistration = this.registerProvider(this.defaultProvider, this.defaultProvider.apiVersion)
     } else {
       if (this.defaultProviderRegistration) {
         this.defaultProviderRegistration.dispose()

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -4,6 +4,7 @@ const ProviderConfig = require('./provider-config')
 module.exports =
 class SubsequenceProvider {
   constructor (options = {}) {
+    this.apiVersion = 4
     this.defaults()
 
     this.subscriptions = new CompositeDisposable()

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -46,7 +46,7 @@ class SubsequenceProvider {
     this.atomConfig = atom.config
     this.atomWorkspace = atom.workspace
 
-    this.possibileWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('')
+    this.possibleWordCharacters = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('')
     this.enableExtendedUnicodeSupport = false
     this.maxSuggestions = 20
     this.maxResultsPerBuffer = 20
@@ -69,7 +69,7 @@ class SubsequenceProvider {
 
     let additionalWordCharacters = ''
 
-    this.possibileWordCharacters.forEach(character => {
+    this.possibleWordCharacters.forEach(character => {
       if (!nonWordCharacters.includes(character)) {
         additionalWordCharacters += character
       }

--- a/lib/symbol-provider.js
+++ b/lib/symbol-provider.js
@@ -8,6 +8,7 @@ import SymbolStore from './symbol-store'
 
 export default class SymbolProvider {
   constructor () {
+    this.apiVersion = 3
     this.defaults()
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableExtendedUnicodeSupport', enableExtendedUnicodeSupport => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "1.0.0": "consumeProvider_1",
         "1.1.0": "consumeProvider_1_1",
         "2.0.0": "consumeProvider_2",
-        "3.0.0": "consumeProvider_3"
+        "3.0.0": "consumeProvider_3",
+        "4.0.0": "consumeProvider_4"
       }
     },
     "snippets": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "marked": "^0.3.6",
     "minimatch": "^3.0.3",
     "selector-kit": "^0.1",
-    "semver": "^5.3.0",
     "stable": "^0.1.5",
     "underscore-plus": "^1.6.6"
   },
@@ -36,10 +35,10 @@
   "consumedServices": {
     "autocomplete.provider": {
       "versions": {
-        "1.0.0": "consumeProvider_1_0",
+        "1.0.0": "consumeProvider_1",
         "1.1.0": "consumeProvider_1_1",
-        "2.0.0": "consumeProvider_2_0",
-        "3.0.0": "consumeProvider_3_0"
+        "2.0.0": "consumeProvider_2",
+        "3.0.0": "consumeProvider_3"
       }
     },
     "snippets": {

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -586,6 +586,42 @@ describe('Autocomplete Manager', () => {
         waitForAutocomplete()
         runs(() => expect(prefix).toBe(' '))
       })
+
+      describe('providers using the 4.0 API', () => {
+        it('accounts for word characters of the current language', () => {
+          let prefix = null
+          const provider = {
+            scopeSelector: '*',
+            inclusionPriority: 2,
+            excludeLowerPriority: true,
+            getSuggestions ({prefix: p}) { prefix = p }
+          }
+
+          mainModule.consumeProvider(provider, 4)
+
+          atom.config.set('editor.nonWordCharacters', '-')
+          editor.insertText(' $foo-$ba')
+          editor.insertText('r')
+          waitForAutocomplete()
+          runs(() => expect(prefix).toBe('$bar'))
+        })
+
+        it('is an empty string when the cursor does not follow a word character', () => {
+          let prefix = null
+          const provider = {
+            scopeSelector: '*',
+            inclusionPriority: 2,
+            excludeLowerPriority: true,
+            getSuggestions ({prefix: p}) { prefix = p }
+          }
+
+          mainModule.consumeProvider(provider, 4)
+          editor.insertText(' foo')
+          editor.insertText('.')
+          waitForAutocomplete()
+          runs(() => expect(prefix).toBe(''))
+        })
+      })
     })
 
     describe('when the character entered is not at the cursor position', () => {

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -542,10 +542,10 @@ describe('Autocomplete Manager', () => {
       })
 
       it('calls with word prefix containing a dash', () => {
-        editor.insertText('_okyea')
+        editor.insertText('-okyea')
         editor.insertText('h')
         waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc_okyeah'))
+        runs(() => expect(prefix).toBe('abc-okyeah'))
       })
 
       it('calls with space character', () => {

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -77,7 +77,7 @@ describe('Autocomplete Manager', () => {
             return (list.map((text) => ({text})))
           }
         }
-        mainModule.consumeProvider(provider)
+        mainModule.consumeProvider(provider, 3)
       })
     })
 
@@ -1140,6 +1140,35 @@ describe('Autocomplete Manager', () => {
           let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
           atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
           expect(editor.getText()).toBe('abc.something')
+        })
+      })
+
+      describe('providers using the 4.0 API', () => {
+        it('replaces the entire prefix by default, regardless of the characters it contains', () => {
+          atom.config.set('editor.nonWordCharacters', '-')
+          provider = {
+            scopeSelector: '*',
+            inclusionPriority: 100,
+            excludeLowerPriority: true,
+            getSuggestions ({prefix}) {
+              return [{
+                text: '$food'
+              }]
+            }
+          }
+          mainModule.consumeProvider(provider, 4)
+
+          editor.setText('')
+          editor.insertText('$food $fo')
+          editor.insertText('o')
+          waitForAutocomplete()
+
+          runs(() => {
+            expect(editorView.querySelector('.autocomplete-plus')).toExist()
+            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+            expect(editor.getText()).toBe('$food $food')
+          })
         })
       })
     })

--- a/spec/provider-manager-spec.js
+++ b/spec/provider-manager-spec.js
@@ -62,10 +62,10 @@ describe('Provider Manager', () => {
       expect(providerManager.isProviderRegistered(testProvider)).toEqual(false)
       expect(hasDisposable(providerManager.subscriptions, testProvider)).toBe(false)
 
-      providerManager.addProvider(testProvider, '3.0.0')
+      providerManager.addProvider(testProvider, 3)
       expect(providerManager.isProviderRegistered(testProvider)).toEqual(true)
       let apiVersion = providerManager.apiVersionForProvider(testProvider)
-      expect(apiVersion).toEqual('3.0.0')
+      expect(apiVersion).toEqual(3)
       expect(hasDisposable(providerManager.subscriptions, testProvider)).toBe(true)
     })
 
@@ -88,9 +88,9 @@ describe('Provider Manager', () => {
         scopeSelector: '.source.js',
         dispose () {}
       }
-      expect(providerManager.isValidProvider({}, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider({}, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, 3)).toEqual(true)
     })
 
     it('can identify a provider with an invalid getSuggestions', () => {
@@ -99,9 +99,9 @@ describe('Provider Manager', () => {
         scopeSelector: '.source.js',
         dispose () {}
       }
-      expect(providerManager.isValidProvider({}, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider({}, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, 3)).toEqual(true)
     })
 
     it('can identify a provider with a missing scope selector', () => {
@@ -110,8 +110,8 @@ describe('Provider Manager', () => {
         aSelector: '.source.js',
         dispose () {}
       }
-      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(bogusProvider, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, 3)).toEqual(true)
     })
 
     it('can identify a provider with an invalid scope selector', () => {
@@ -120,8 +120,8 @@ describe('Provider Manager', () => {
         scopeSelector: '',
         dispose () {}
       }
-      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(bogusProvider, 3)).toEqual(false)
+      expect(providerManager.isValidProvider(testProvider, 3)).toEqual(true)
 
       bogusProvider = {
         getSuggestions (options) {},
@@ -129,7 +129,7 @@ describe('Provider Manager', () => {
         dispose () {}
       }
 
-      expect(providerManager.isValidProvider(bogusProvider, '3.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, 3)).toEqual(false)
     })
 
     it('correctly identifies a 1.0 provider', () => {
@@ -138,15 +138,15 @@ describe('Provider Manager', () => {
         requestHandler: 'yo, this is a bad handler',
         dispose () {}
       }
-      expect(providerManager.isValidProvider({}, '1.0.0')).toEqual(false)
-      expect(providerManager.isValidProvider(bogusProvider, '1.0.0')).toEqual(false)
+      expect(providerManager.isValidProvider({}, 1)).toEqual(false)
+      expect(providerManager.isValidProvider(bogusProvider, 1)).toEqual(false)
 
       let legitProvider = {
         selector: '.source.js',
         requestHandler () {},
         dispose () {}
       }
-      expect(providerManager.isValidProvider(legitProvider, '1.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(legitProvider, 1)).toEqual(true)
     })
 
     it('registers a valid provider', () => {
@@ -231,7 +231,7 @@ describe('Provider Manager', () => {
         }
       }
 
-      expect(providerManager.isValidProvider(testProvider, '3.0.0')).toEqual(true)
+      expect(providerManager.isValidProvider(testProvider, 3)).toEqual(true)
 
       expect(providerManager.applicableProviders(['workspace-center'], '.source.js').length).toEqual(1)
       expect(providerManager.applicableProviders(['workspace-center'], '.source.js').indexOf(testProvider)).toBe(-1)

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -273,7 +273,11 @@ describe('SubsequenceProvider', () => {
         waitsForPromise(() =>
           suggestionsForPrefix(provider, editor, 'good').then(sugs => {
             expect(sugs).not.toContain('good-noodles')
-            atom.config.set('editor.nonWordCharacters', '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…')
+            atom.config.set(
+              'editor.nonWordCharacters',
+              '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…',
+              {scopeSelector: editor.getLastCursor().getScopeDescriptor().getScopeChain()}
+            )
             return suggestionsForPrefix(provider, editor, 'good')
           }).then(sugs => {
             expect(sugs).toContain('good-noodles')

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -273,11 +273,7 @@ describe('SubsequenceProvider', () => {
         waitsForPromise(() =>
           suggestionsForPrefix(provider, editor, 'good').then(sugs => {
             expect(sugs).not.toContain('good-noodles')
-            atom.config.set(
-              'editor.nonWordCharacters',
-              '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…',
-              {scopeSelector: editor.getLastCursor().getScopeDescriptor().getScopeChain()}
-            )
+            atom.config.set('editor.nonWordCharacters', '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…')
             return suggestionsForPrefix(provider, editor, 'good')
           }).then(sugs => {
             expect(sugs).toContain('good-noodles')


### PR DESCRIPTION
🍐 d with @maxbrunsfeld 

### Description of the Change

Autocomplete providers are passed a *prefix* string, which describes the characters preceding the cursor.

Previously, in API v3, this prefix was computed based on a regular expression in this package. It would recognize a fixed set of word characters or a sequence of non-word characters. Unfortunately, this clashed with the fact that different languages have different sets of valid word characters.

When @leroix added the subsequence provider in #886, he introduced the ability to complete words containing symbols, such as `$hello`. Unfortunately, since the *prefix* did not include the leading `$` based on an assumption it was a non-word character, returning a completion of `$hello` would cause a duplication due to the prefix not including the `$`, yielding `$$hello`.

In #930, @leroix changed prefix calculation to use the `Cursor.getCurrentWordPrefix` method, but this was problematic for a couple of reasons.
  1) It was a breaking change, causing different prefixes to be passed to providers than they previously assumed
  2) The `getCurrentWordPrefix` method has a misleading name, and it actually returns contiguous runs of word or non-word characters in order to support cursor movement.

In this PR, we revert #930 and restore the original prefix behavior for API version 3. We then introduce API version 4, which changes the prefix computation as follows:

* We only ever include characters that are part of a word. If autocomplete is triggered following a non-word character, the prefix is an empty string. In these cases, the buffer can be inspected directly based on the given position and the provider can do whatever it wants.
* Unless they are explicitly black-listed in the `editor.nonWordCharacters` setting, the following characters are allowed within words: `/\()"':,.;<>~!@#$%^&*|+=[]{}``?_-…`. Most of these are excluded by default, but certain languages may relax the default non-word characters to allow characters like `-` or `$` to be included in words.
* The `replacementPrefix` is always defaulted to the `prefix` passed to the provider if no `replacementPrefix` is specified for a suggestion.

This PR also simplifies our handling of semver. Since we only need to deal with breaking changes, it replaces semver strings with simple integer comparisons.

### Alternate Designs

We could have special-cased the `SubsequenceProvider` to compute its own prefix. In fact, we tried this in order to turn this change around more quickly, but then realized that fixing its tests would take more time and effort than just fundamentally improving the prefix calculation in a new API version.

### Benefits

Fixes #855
Fixes breakage raised in https://github.com/atom/autocomplete-plus/pull/930#issuecomment-353615820

### Possible Drawbacks

Yet another API version for completion providers, and we still support version 1.0.

### Applicable Issues

Fixes #855
