### PR TITLE
Add `autocomplete.extraWordCharacters` setting

### DIFF
--- a/lib/get-additional-word-characters.js
+++ b/lib/get-additional-word-characters.js
@@ -3,12 +3,11 @@ const POSSIBLE_WORD_CHARACTERS = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('
 module.exports =
 function getAdditionalWordCharacters (scopeDescriptor) {
   const nonWordCharacters = atom.config.get('editor.nonWordCharacters', {scope: scopeDescriptor})
-  let additionalWordCharacters = ''
+  let result = atom.config.get('autocomplete.extraWordCharacters', {scope: scopeDescriptor})
   POSSIBLE_WORD_CHARACTERS.forEach(character => {
     if (!nonWordCharacters.includes(character)) {
-      additionalWordCharacters += character
+      result += character
     }
   })
-
-  return additionalWordCharacters
+  return result
 }

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -1,5 +1,6 @@
 const { CompositeDisposable, TextBuffer } = require('atom')
 const ProviderConfig = require('./provider-config')
+const getAdditionalWordCharacters = require('./get-additional-word-characters')
 
 module.exports =
 class SubsequenceProvider {
@@ -63,20 +64,6 @@ class SubsequenceProvider {
 
   dispose () {
     return this.subscriptions.dispose()
-  }
-
-  getAdditionalWordCharacters (scopeDescriptor) {
-    const nonWordCharacters = this.atomConfig.get('editor.nonWordCharacters', {scope: scopeDescriptor})
-
-    let additionalWordCharacters = ''
-
-    this.possibleWordCharacters.forEach(character => {
-      if (!nonWordCharacters.includes(character)) {
-        additionalWordCharacters += character
-      }
-    })
-
-    return additionalWordCharacters
   }
 
   watchBuffer (editor) {
@@ -172,7 +159,7 @@ class SubsequenceProvider {
 
     const lastCursorRow = editor.getLastCursor().getBufferPosition().row
 
-    const additionalWordCharacters = this.getAdditionalWordCharacters(scopeDescriptor)
+    const additionalWordCharacters = getAdditionalWordCharacters(scopeDescriptor)
 
     const configSuggestions = this.providerConfig.getSuggestionsForScopeDescriptor(
       scopeDescriptor

--- a/lib/subsequence-provider.js
+++ b/lib/subsequence-provider.js
@@ -170,12 +170,6 @@ class SubsequenceProvider {
       prefix
     )
 
-    const wordsUnderCursors = editor.getCursors().reduce((words, cursor) => {
-      const word = editor.getBuffer().getTextInRange(cursor.getCurrentWordBufferRange())
-      words[word] = true
-      return words
-    }, {})
-
     const subsequenceMatchToType = (match) => {
       const editor = this.watchedBuffers.get(match.buffer)
       const scopeDescriptor = editor.scopeDescriptorForBufferPosition(match.positions[0])
@@ -221,7 +215,7 @@ class SubsequenceProvider {
 
           if (matchedWords.hasOwnProperty(match.word)) continue
 
-          if (wordsUnderCursors[match.word]) continue
+          if (match.word === prefix) continue
 
           if (this.strictMatching && match.word.indexOf(prefix) !== 0) continue
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,12 @@
       "default": 3,
       "order": 10
     },
+    "extraWordCharacters": {
+      "description": "Characters to consider part of words for the purpose of autocomplete, even if they are included in the editor.nonWordCharacters setting",
+      "type": "string",
+      "default": "",
+      "order": 10.5
+    },
     "enableBuiltinProvider": {
       "title": "Enable Built-In Provider",
       "description": "The package comes with a built-in provider that will provide suggestions using the words in your current buffer or all open buffers. You will get better suggestions by installing additional autocomplete+ providers. To stop using the built-in provider, disable this option.",

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -110,28 +110,17 @@ describe('SubsequenceProvider', () => {
       })
     })
 
-    it('does not return the word under the cursor when there is only a prefix', () => {
+    it('does not return the prefix as a suggestion', () => {
+      atom.config.set('editor.nonWordCharacters', '-')
+      atom.config.set('autocomplete.extraWordCharacters', '-')
+
       editor.moveToBottom()
-      editor.insertText('qu')
+      editor.insertText('--qu')
       waitForBufferToStopChanging()
 
       waitsForPromise(() => {
-        return suggestionsForPrefix(provider, editor, 'qu').then(sugs => {
-          expect(sugs).not.toContain('qu')
-        })
-      })
-    })
-
-    it('does not return the word under the cursor when there is a suffix and only one instance of the word', () => {
-      editor.moveToBottom()
-      editor.insertText('catscats')
-      editor.moveToBeginningOfLine()
-      editor.insertText('omg')
-
-      waitsForPromise(() => {
-        return suggestionsForPrefix(provider, editor, 'omg').then(sugs => {
-          expect(sugs).not.toContain('omg')
-          expect(sugs).not.toContain('omgcatscats')
+        return suggestionsForPrefix(provider, editor, '--qu').then(sugs => {
+          expect(sugs).not.toContain('--qu')
         })
       })
     })


### PR DESCRIPTION
Fixes https://github.com/atom/language-html/issues/184

After landing the new autocomplete subsequence provider, we starting using the `editor.nonWordCharacters` setting to identify words for the purposes of autocomplete. We thought this was improvement over the old strategy that used a hard-coded regex, but it turns out that people expect Atom's word-movement commands to define words differently than autocomplete (see https://github.com/atom/language-html/issues/184).

This PR introduces a *new* setting - `autocomplete.extraWordCharacters` that can be used to further customize the way that we find words for autocomplete. This setting will enable us to revert https://github.com/atom/language-html/commit/4fa8731bf51456ae618379aaceb103d2bc2f0b17, https://github.com/atom/language-css/commit/f72f3bd90797ecf8dcc19a215cbd7ffb0cd25037, https://github.com/atom/language-less/commit/4da4be28f035fd3adbcf329de15fca4429aaab67, and https://github.com/atom/language-clojure/commit/1a5b3b2c76a6d5850a3cc38c5a9f3c01ff05e874. Instead, in these language packages, we will include the dash character in the `autocomplete.extraWordCharacters` setting.

🍐 d with @nathansobo 