### PR TITLE
Fix validation issue for navigate-to-description-more-link

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -224,7 +224,7 @@ class AutocompleteManager {
       'autocomplete-plus:navigate-to-description-more-link': () => {
         let suggestionListView = atom.views.getView(this.editor)
         let descriptionContainer = suggestionListView.querySelector('.suggestion-description')
-        if (descriptionContainer.style.display === 'block') {
+        if (descriptionContainer !== null && descriptionContainer.style.display === 'block') {
           let descriptionMoreLink = descriptionContainer.querySelector('.suggestion-description-more-link')
           require('shell').openExternal(descriptionMoreLink.href)
         }


### PR DESCRIPTION
Related to issue 16600 from repo /atom/atom
### Description of the Change
This issue solves the bug mentioned in [issue](https://github.com/atom/atom/issues/16600). The problem arose because the ```.suggestion-description``` container doesn't exist when the user triggers the command palette, therefore a condition was needed.

### Alternate Designs
Not sure if navigate-to-description-more-link could be removed from the command palette but still work with the key binding, but this would make the functionality harder to find. Open to comments.

### Benefits
The error doesn't pop-up.

### Possible Drawbacks
Not that I can think of.

### Applicable Issues
[16600](https://github.com/atom/atom/issues/16600)

## Demo
![video](https://user-images.githubusercontent.com/18427801/36063281-bd86d960-0e48-11e8-915a-9c5220db73e2.gif)

