### PR TITLE
Apply "moveToCancel" preference to all movement commands.

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -206,23 +206,49 @@ module.exports = class SuggestionListElement {
 
   moveSelectionPageUp () {
     const newIndex = Math.max(0, this.selectedIndex - this.maxVisibleSuggestions)
-    if (this.selectedIndex !== newIndex) { return this.setSelectedIndex(newIndex) }
+
+    if (this.moveToCancel) {
+      const lines = this.model.activeEditor.getScreenLineCount()
+      this.model.activeEditor.moveUp(lines)
+      return this.model.cancel()
+    } else if (this.selectedIndex !== newIndex) {
+      return this.setSelectedIndex(newIndex)
+    }
   }
 
   moveSelectionPageDown () {
     const itemsLength = this.visibleItems().length
     const newIndex = Math.min(itemsLength - 1, this.selectedIndex + this.maxVisibleSuggestions)
-    if (this.selectedIndex !== newIndex) { return this.setSelectedIndex(newIndex) }
+
+    if (this.moveToCancel) {
+      const lines = this.model.activeEditor.getScreenLineCount()
+      this.model.activeEditor.moveDown(lines)
+      return this.model.cancel()
+    } else if (this.selectedIndex !== newIndex) {
+      return this.setSelectedIndex(newIndex)
+    }
   }
 
   moveSelectionToTop () {
     const newIndex = 0
-    if (this.selectedIndex !== newIndex) { return this.setSelectedIndex(newIndex) }
+
+    if (this.moveToCancel) {
+      this.model.activeEditor.moveToTop()
+      return this.model.cancel()
+    } else if (this.selectedIndex !== newIndex) {
+      return this.setSelectedIndex(newIndex)
+    }
   }
 
   moveSelectionToBottom () {
     const newIndex = this.visibleItems().length - 1
-    if (this.selectedIndex !== newIndex) { return this.setSelectedIndex(newIndex) }
+
+    if (this.moveToCancel) {
+      this.model.activeEditor.moveToBottom()
+      return this.model.cancel()
+    } else if (this.selectedIndex !== newIndex) {
+      return this.setSelectedIndex(newIndex)
+    }
   }
 
   setSelectedIndex (index) {

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -281,9 +281,9 @@ describe('Suggestion List Element', () => {
     it('dismisses the suggestion list if the current selection is at the start of the list and moveToCancel is true', () => {
       const model = {
         activeEditor: {
-          moveUp() {}
+          moveUp () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveUp')
       spyOn(model, 'cancel')
@@ -322,9 +322,9 @@ describe('Suggestion List Element', () => {
     it('dismisses the suggestion list if the current selection is at the end of the list and moveToCancel is true', () => {
       const model = {
         activeEditor: {
-          moveDown() {}
+          moveDown () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
@@ -356,9 +356,9 @@ describe('Suggestion List Element', () => {
       const model = {
         activeEditor: {
           getScreenLineCount: () => 42,
-          moveUp() {}
+          moveUp () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveUp')
       spyOn(model, 'cancel')
@@ -378,9 +378,9 @@ describe('Suggestion List Element', () => {
       const model = {
         activeEditor: {
           getScreenLineCount: () => 42,
-          moveDown() {}
+          moveDown () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
@@ -400,9 +400,9 @@ describe('Suggestion List Element', () => {
     it('dismisses the list if moveToCancel is true', () => {
       const model = {
         activeEditor: {
-          moveToTop() {}
+          moveToTop () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveToTop')
       spyOn(model, 'cancel')
@@ -421,9 +421,9 @@ describe('Suggestion List Element', () => {
     it('dismisses the list if moveToCancel is true', () => {
       const model = {
         activeEditor: {
-          moveToBottom() {}
+          moveToBottom () {}
         },
-        cancel() {}
+        cancel () {}
       }
       spyOn(model.activeEditor, 'moveToBottom')
       spyOn(model, 'cancel')

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -267,4 +267,175 @@ describe('Suggestion List Element', () => {
       expect(suggestionListElement.removeEmptySnippets('hello${1000:}hello')).toBe('hellohello')
     })
   })
+
+  describe('moveSelectionUp', () => {
+    it('decreases the selected index when the current index is greater than zero', () => {
+      spyOn(suggestionListElement, 'setSelectedIndex')
+      suggestionListElement.selectedIndex = 1
+
+      suggestionListElement.moveSelectionUp()
+
+      expect(suggestionListElement.setSelectedIndex).toHaveBeenCalledWith(0)
+    })
+
+    it('dismisses the suggestion list if the current selection is at the start of the list and moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          moveUp() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveUp')
+      spyOn(model, 'cancel')
+
+      suggestionListElement.model = model
+      suggestionListElement.selectedIndex = 0
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionUp()
+
+      expect(model.activeEditor.moveUp).toHaveBeenCalledWith(1)
+      expect(model.cancel).toHaveBeenCalled()
+    })
+
+    it('cycles to the last element in the suggestion list when the current selection is at the start of the list', () => {
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'setSelectedIndex')
+
+      suggestionListElement.moveSelectionUp()
+
+      expect(suggestionListElement.setSelectedIndex).toHaveBeenCalledWith(4)
+    })
+  })
+
+  describe('moveSelectionDown', () => {
+    it('increases the selected index if the current selection is not at the end of the list', () => {
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'setSelectedIndex')
+      suggestionListElement.selectedIndex = 3
+
+      suggestionListElement.moveSelectionDown()
+
+      expect(suggestionListElement.setSelectedIndex).toHaveBeenCalledWith(4)
+    })
+
+    it('dismisses the suggestion list if the current selection is at the end of the list and moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          moveDown() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveDown')
+      spyOn(model, 'cancel')
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+
+      suggestionListElement.model = model
+      suggestionListElement.selectedIndex = 4
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionDown()
+
+      expect(model.activeEditor.moveDown).toHaveBeenCalledWith(1)
+      expect(model.cancel).toHaveBeenCalled()
+    })
+
+    it('cycles to the first element in the suggestion list when the current suggestion is at the end of the list', () => {
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'setSelectedIndex')
+      suggestionListElement.selectedIndex = 4
+
+      suggestionListElement.moveSelectionDown()
+
+      expect(suggestionListElement.setSelectedIndex).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('moveSelectionPageUp', () => {
+    it('dismisses the list if moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          getScreenLineCount: () => 42,
+          moveUp() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveUp')
+      spyOn(model, 'cancel')
+
+      suggestionListElement.model = model
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionPageUp()
+
+      expect(model.activeEditor.moveUp).toHaveBeenCalledWith(42)
+      expect(model.cancel).toHaveBeenCalled()
+    })
+  })
+
+  describe('moveSelectionPageDown', () => {
+    it('dismisses the list if moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          getScreenLineCount: () => 42,
+          moveDown() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveDown')
+      spyOn(model, 'cancel')
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
+
+      suggestionListElement.model = model
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionPageDown()
+
+      expect(model.activeEditor.moveDown).toHaveBeenCalledWith(42)
+      expect(model.cancel).toHaveBeenCalled()
+    })
+  })
+
+  describe('moveSelectionToTop', () => {
+    it('dismisses the list if moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          moveToTop() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveToTop')
+      spyOn(model, 'cancel')
+
+      suggestionListElement.model = model
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionToTop()
+
+      expect(model.activeEditor.moveToTop).toHaveBeenCalled()
+      expect(model.cancel).toHaveBeenCalled()
+    })
+  })
+
+  describe('moveSelectionToBottom', () => {
+    it('dismisses the list if moveToCancel is true', () => {
+      const model = {
+        activeEditor: {
+          moveToBottom() {}
+        },
+        cancel() {}
+      }
+      spyOn(model.activeEditor, 'moveToBottom')
+      spyOn(model, 'cancel')
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
+
+      suggestionListElement.model = model
+      suggestionListElement.moveToCancel = true
+
+      suggestionListElement.moveSelectionToBottom()
+
+      expect(model.activeEditor.moveToBottom).toHaveBeenCalled()
+      expect(model.cancel).toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Following #838, this PR updates the movement hooks for Page Up/Down and move-to-top/-bottom such that when the `moveToCancel` preference is enabled, the suggestion list is dismissed and the movement command is applied to the editor.

Here's a quick screencast showing the changes in action:

![screenflow](https://user-images.githubusercontent.com/2207980/36326920-c4dd840c-132a-11e8-88f0-c5c52fb82808.gif)

### Alternate Designs
N/A

### Benefits
The principle behind the `moveToCancel` preference was to emulate the behavior of Sublime Text's autocompletion module. Dismissing the suggestion list when the user attempts to navigate "above" or "below" it was one part of that, but my first pass missed the edge cases where the user might be attempting to move to the top or bottom of the editor or to its next or previous screen. One justification for adding this behavior is therefore to conform more exactly with ST3, which dismisses the suggestion list in these cases; another is that it seems like a reasonable extension of the user expectation that movement commands should be applied to her editor primarily and to her suggestion list as an afterthought.

### Possible Drawbacks
It's possible that I'm misjudging user expectations, in which case modifying the behavior could result in a frustrating tendency to inadvertently dismiss Autocomplete Plus' suggestions.

### Applicable Issues
N/A
