### PR TITLE
Added inline mode (cycles through suggestions without showing suggestion list)

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -43,6 +43,11 @@ class AutocompleteManager {
     this.displaySuggestions = this.displaySuggestions.bind(this)
     this.hideSuggestionList = this.hideSuggestionList.bind(this)
 
+    this.inlineMode = false;
+    this.previousPrefix = null;
+    this.previousReplacement = null;
+    this.previousSuggestionIndex = -1;
+
     this.showOrHideSuggestionListForBufferChanges = this.showOrHideSuggestionListForBufferChanges.bind(this)
     this.providerManager = new ProviderManager()
     this.suggestionList = new SuggestionList()
@@ -190,6 +195,7 @@ class AutocompleteManager {
     this.subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoConfirmSingleSuggestion', (value) => { this.autoConfirmSingleSuggestionEnabled = value }))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.consumeSuffix', (value) => { this.consumeSuffix = value }))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.useAlternateScoring', (value) => { this.useAlternateScoring = value }))
+    this.subscriptions.add(atom.config.observe('autocomplete-plus.inlineMode', (value) => { this.inlineMode = true }))
     this.subscriptions.add(atom.config.observe('autocomplete-plus.fileBlacklist', (value) => {
       if (value) {
         this.fileBlacklist = value.map((s) => { return s.trim() })
@@ -243,7 +249,9 @@ class AutocompleteManager {
 
     const bufferPosition = cursor.getBufferPosition()
     const scopeDescriptor = cursor.getScopeDescriptor()
-    const prefix = this.getPrefix(this.editor, bufferPosition, scopeDescriptor) // Passed to providers with API version >= 4.0.0
+    const prefix = this.inlineMode && this.previousPrefix
+                || this.getPrefix(this.editor, bufferPosition, scopeDescriptor) // Passed to providers with API version >= 4.0.0
+    this.previousPrefix = prefix;
     const legacyPrefix = this.getLegacyPrefix(this.editor, bufferPosition) // Passed to providers with API version < 4.0.0
 
     return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, legacyPrefix, activatedManually})
@@ -351,6 +359,9 @@ class AutocompleteManager {
         if (options.activatedManually && this.shouldDisplaySuggestions && this.autoConfirmSingleSuggestionEnabled && suggestions.length === 1) {
           // When there is one suggestion in manual mode, just confirm it
           return this.confirm(suggestions[0])
+        } else if (options.activatedManually && this.inlineMode && suggestions.length >= 1) {
+          this.previousSuggestionIndex = (this.previousSuggestionIndex + 1) % suggestions.length;
+          return this.confirm(suggestions[this.previousSuggestionIndex], true)
         } else {
           return this.displaySuggestions(suggestions, options)
         }
@@ -528,7 +539,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   // Private: Gets called when the user successfully confirms a suggestion
   //
   // match - An {Object} representing the confirmed suggestion
-  confirm (suggestion) {
+  confirm (suggestion, keepSuggestionList) {
     if ((this.editor == null) || (suggestion == null) || !!this.disposed) { return }
 
     const apiVersion = this.providerManager.apiVersionForProvider(suggestion.provider)
@@ -548,7 +559,8 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       }
     }
 
-    this.hideSuggestionList()
+    // when manually triggered, and in inlineMode, we don't want to reset the suggestions
+    if (!keepSuggestionList) this.hideSuggestionList()
 
     this.replaceTextWithMatch(suggestion)
 
@@ -583,6 +595,10 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     this.suggestionList.changeItems(null)
     this.suggestionList.hide()
     this.shouldDisplaySuggestions = false
+    // reset the inlineMode state
+    this.previousPrefix = null;
+    this.previousReplacement = null;
+    this.previousSuggestionIndex = -1;
   }
 
   requestHideSuggestionList (command) {
@@ -613,17 +629,21 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       for (let i = 0; i < cursors.length; i++) {
         const cursor = cursors[i]
         const endPosition = cursor.getBufferPosition()
-        const beginningPosition = [endPosition.row, endPosition.column - suggestion.replacementPrefix.length]
+        //const beginningPosition = [endPosition.row, endPosition.column - suggestion.replacementPrefix.length]
+        const prefix = this.inlineMode && this.previousReplacement || suggestion.replacementPrefix;
+        const beginningPosition = [endPosition.row, endPosition.column - prefix.length]
 
-        if (this.editor.getTextInBufferRange([beginningPosition, endPosition]) === suggestion.replacementPrefix) {
+        if (this.editor.getTextInBufferRange([beginningPosition, endPosition]) === prefix) {
           const suffix = this.consumeSuffix ? this.getSuffix(this.editor, endPosition, suggestion) : ''
           if (suffix.length) { cursor.moveRight(suffix.length) }
-          cursor.selection.selectLeft(suggestion.replacementPrefix.length + suffix.length)
+          cursor.selection.selectLeft(prefix.length + suffix.length)
 
           if ((suggestion.snippet != null) && (this.snippetsManager != null)) {
             this.snippetsManager.insertSnippet(suggestion.snippet, this.editor, cursor)
           } else {
-            cursor.selection.insertText(suggestion.text != null ? suggestion.text : suggestion.snippet, {
+            const text = suggestion.text != null ? suggestion.text : suggestion.snippet;
+            this.previousReplacement = text;
+            cursor.selection.insertText(text, {
               autoIndentNewline: this.editor.shouldAutoIndent(),
               autoDecreaseIndent: this.editor.shouldAutoIndent()
             })
@@ -722,6 +742,11 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
 
   showOrHideSuggestionListForBufferChanges ({changes}) {
     if (this.disposed) return
+    if (this.inlineMode && this.previousPrefix
+        && changes.some(({oldText, newText}) => newText === this.previousReplacement)) {
+      this.cancelHideSuggestionListRequest()
+      return
+    }
 
     const lastCursorPosition = this.editor.getLastCursor().getBufferPosition()
     const changeOccurredNearLastCursor = changes.some(({newRange}) => {
@@ -747,7 +772,6 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
           }
         }
       })
-
       if (shouldActivate && this.shouldSuppressActivationForEditorClasses()) shouldActivate = false
     }
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "title": "Inline Mode",
       "description": "The activation key will cycle through the suggestions without showing the suggestion list.",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "order": 3.5
     },
     "confirmCompletion": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "autocomplete-plus",
-  "version": "2.40.4",
+  "version": "2.40.4+eweitnauer",
   "main": "./lib/main",
   "description": "Display possible completions in the editor while typing",
-  "repository": "https://github.com/atom/autocomplete-plus",
+  "repository": "https://github.com/eweitnauer/autocomplete-plus",
   "license": "MIT",
   "engines": {
     "atom": ">=0.189.0 <2.0.0"
@@ -70,6 +70,13 @@
       "default": 10,
       "minimum": 1,
       "order": 3
+    },
+    "inlineMode": {
+      "title": "Inline Mode",
+      "description": "The activation key will cycle through the suggestions without showing the suggestion list.",
+      "type": "boolean",
+      "default": true,
+      "order": 3.5
     },
     "confirmCompletion": {
       "title": "Keymap For Confirming A Suggestion",


### PR DESCRIPTION
### Description of the Change

I find the suggestion list in autocomplete+ distracting and wanted a mode that cycles through the suggestions without showing the list. I added a new setting called "Inline Mode" to the code that a user can activate to do just that: cycle through all suggestions by repeatedly pressing the autocomplete activation key.

![inline-autocomplete](https://user-images.githubusercontent.com/53043/36704114-e612b8a4-1b2c-11e8-8086-4810c2ae0d39.gif)

### Alternate Designs

This actually is an alternative design to the existing suggestion menu. It provides basically the same functionality as the existing plugin [Atom Inline Autocomplete](https://github.com/alexchee/atom-inline-autocomplete), but works within the autocomplete+ framework.

### Benefits

1. Offers an additional, visually less distracting way of triggering auto-completion.
2. May help persons coming from Textmate or Sublime Text, who are used to this type of auto-completion.

### Possible Drawbacks

Since it is an optional mode, I don't see any drawbacks.

### Applicable Issues

–

----

I made this pull request to get feedback on the code. I expect there are more elegant ways to implement it, and I am not sure if it is compatible with all use-cases that autocomplete+ supports. After a code review, I plan to make improvements as requested and add test cases to the specs.