### PR TITLE
fix using autocomplete instead of autocomplete-plus to retrieve config

### DIFF
--- a/lib/get-additional-word-characters.js
+++ b/lib/get-additional-word-characters.js
@@ -3,7 +3,7 @@ const POSSIBLE_WORD_CHARACTERS = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?_-…'.split('
 module.exports =
 function getAdditionalWordCharacters (scopeDescriptor) {
   const nonWordCharacters = atom.config.get('editor.nonWordCharacters', {scope: scopeDescriptor})
-  let result = atom.config.get('autocomplete.extraWordCharacters', {scope: scopeDescriptor})
+  let result = atom.config.get('autocomplete-plus.extraWordCharacters', {scope: scopeDescriptor})
   POSSIBLE_WORD_CHARACTERS.forEach(character => {
     if (!nonWordCharacters.includes(character)) {
       result += character

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -112,7 +112,7 @@ describe('SubsequenceProvider', () => {
 
     it('does not return the prefix as a suggestion', () => {
       atom.config.set('editor.nonWordCharacters', '-')
-      atom.config.set('autocomplete.extraWordCharacters', '-')
+      atom.config.set('autocomplete-plus.extraWordCharacters', '-')
 
       editor.moveToBottom()
       editor.insertText('--qu')
@@ -256,7 +256,7 @@ describe('SubsequenceProvider', () => {
     )
 
     describe('when editor.nonWordCharacters changes', () => {
-      it('includes characters that are included in the `autocomplete.extraWordCharacters` setting or not excluded in the `editor.nonWordCharacters` setting', () => {
+      it('includes characters that are included in the `autocomplete-plus.extraWordCharacters` setting or not excluded in the `editor.nonWordCharacters` setting', () => {
         waitsForPromise(async () => {
           const scopeSelector = editor.getLastCursor().getScopeDescriptor().getScopeChain()
           editor.insertText('good$noodles good-beef ')
@@ -266,7 +266,7 @@ describe('SubsequenceProvider', () => {
           expect(sugs).not.toContain('good$noodles')
           expect(sugs).not.toContain('good-beef')
 
-          atom.config.set('autocomplete.extraWordCharacters', '-', {scopeSelector})
+          atom.config.set('autocomplete-plus.extraWordCharacters', '-', {scopeSelector})
           sugs = await suggestionsForPrefix(provider, editor, 'good')
           expect(sugs).toContain('good-beef')
           expect(sugs).not.toContain('good$noodles')


### PR DESCRIPTION
Fix #956.

## How the actual code works

https://github.com/atom/autocomplete-plus/blob/edf3db30c04340bbfea1fa5001832e2d16061179/lib/get-additional-word-characters.js#L6
is assigned to `undefined`, because the configuration key is invalid.

Then, `POSSIBLE_WORD_CHARACTERS` that aren’t in `editor.nonWordCharacters` are added at the end of `result`. In JavaScript, concatenating `undefined` and a letter, let’s say '_', produces a string: `"undefined_"`.

The string is then incorporated in the regex there:

https://github.com/atom/autocomplete-plus/blob/edf3db30c04340bbfea1fa5001832e2d16061179/lib/autocomplete-manager.js#L513

As the regex already matches for ASCII letters, this doesn’t cause an issue in the general case.

## The bug

When you add `_` to `editor.nonWordCharacters`, then `POSSIBLE_WORD_CHARACTERS` and `editor.nonWordCharacters` are equals, then no concatenation takes place, and result stays `undefined`. Then, the above code line crash because you can’t use `.replace()` on `undefined`.

## The fix

Using `'autocomplete-plus.extraWordCharacters'` to effectively get the configuration and fix, in fact, two bugs:

- If `extraWordCharacters` is not used, result is assigned to its default value (the empty string) instead of undefined, and the package will never crash.
- If `extraWordCharacters` is used, now it’s taken into account!

Thanks to @BojanOro for [his comment](https://github.com/atom/autocomplete-plus/issues/956#issuecomment-374462000) that set me on the right track.