### PR TITLE
Fix autocomplete regex to work with strings containing numbers.

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -510,7 +510,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     let regex = wordCharacterRegexCache.get(additionalWordChars)
 
     if (!regex) {
-      regex = new RegExp(`[${UnicodeLetters}${additionalWordChars.replace(']', '\\]')}]`)
+      regex = new RegExp(`[${UnicodeLetters}${additionalWordChars.replace(']', '\\]')}\\d]`)
       wordCharacterRegexCache.set(additionalWordChars, regex)
     }
     return regex


### PR DESCRIPTION
Reference:

https://github.com/atom/autocomplete-plus/issues/950

### Description of the Change

The regex used for autocomplete lookup was not working properly with strings that contained numbers.  This had the following effects:
- autocomplete suggestions would disappear once the user typed a number
- selecting the suggested completion would insert extra characters, for example if the user was trying to autocomplete "P3Package", if they typed "P3Pack" and selected "P3Package" from the autocomplete suggestions, "P3P3Package" would be inserted.

This fix includes all digits in the regex, and was suggested by user Aerijo in the comments about issue 950: https://github.com/atom/autocomplete-plus/issues/950


### Alternate Designs

N/A

### Benefits

Autocomplete on strings containing numbers works properly.

### Possible Drawbacks

Unknown, no regression test created but functional test on local machine worked properly.

### Applicable Issues

#950 
