### PR TITLE
[Request For Comment]Add keybinding to quickly select a suggestion

### DIFF
--- a/keymaps/autocomplete-plus.cson
+++ b/keymaps/autocomplete-plus.cson
@@ -4,3 +4,12 @@
 'atom-text-editor.autocomplete-active':
   'escape': 'autocomplete-plus:cancel'
   'f1': 'autocomplete-plus:navigate-to-description-more-link'
+  'cmd-1': 'autocomplete-plus:menu:1'
+  'cmd-2': 'autocomplete-plus:menu:2'
+  'cmd-3': 'autocomplete-plus:menu:3'
+  'cmd-4': 'autocomplete-plus:menu:4'
+  'cmd-5': 'autocomplete-plus:menu:5'
+  'cmd-6': 'autocomplete-plus:menu:6'
+  'cmd-7': 'autocomplete-plus:menu:7'
+  'cmd-8': 'autocomplete-plus:menu:8'
+  'cmd-9': 'autocomplete-plus:menu:9'

--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -229,8 +229,24 @@ class AutocompleteManager {
           let descriptionMoreLink = descriptionContainer.querySelector('.suggestion-description-more-link')
           require('shell').openExternal(descriptionMoreLink.href)
         }
-      }
+      },
+      'autocomplete-plus:menu:1': () => { this.selectSuggestionAndConfirm(1) },
+      'autocomplete-plus:menu:2': () => { this.selectSuggestionAndConfirm(2) },
+      'autocomplete-plus:menu:3': () => { this.selectSuggestionAndConfirm(3) },
+      'autocomplete-plus:menu:4': () => { this.selectSuggestionAndConfirm(4) },
+      'autocomplete-plus:menu:5': () => { this.selectSuggestionAndConfirm(5) },
+      'autocomplete-plus:menu:6': () => { this.selectSuggestionAndConfirm(6) },
+      'autocomplete-plus:menu:7': () => { this.selectSuggestionAndConfirm(7) },
+      'autocomplete-plus:menu:8': () => { this.selectSuggestionAndConfirm(8) },
+      'autocomplete-plus:menu:9': () => { this.selectSuggestionAndConfirm(9) }
     }))
+  }
+
+  selectSuggestionAndConfirm (itemIndex) {
+    let item = this.suggestionList.getSuggestionAtIndex(itemIndex)
+    if (item !== null) {
+      this.confirm(item)
+    }
   }
 
   // Private: Finds suggestions for the current prefix, sets the list items,

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -3,10 +3,11 @@ const SnippetParser = require('./snippet-parser')
 const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const marked = require('marked')
+const suggestionShortcut = require('./suggestion-shortcut')
 
 const createSuggestionFrag = () => {
   const frag = document.createDocumentFragment()
-  const children = ['icon-container', 'left-label', 'word-container', 'right-label']
+  const children = ['icon-container', 'shortcut', 'left-label', 'word-container', 'right-label']
   children.forEach(c => {
     let el = document.createElement('span')
     el.className = c
@@ -518,6 +519,14 @@ module.exports = class SuggestionListElement {
       rightLabelSpan.textContent = rightLabel
     } else {
       rightLabelSpan.textContent = ''
+    }
+
+    const shortcutSpan = li.querySelector('.shortcut')
+    let keystrokes = suggestionShortcut.getKeyStrokeNotation(index)
+    if (keystrokes != null) {
+      shortcutSpan.innerHTML = `<i class='icon-shortcut'>${keystrokes.substring(0, 1)}</i>${keystrokes.substring(1)}`
+    } else {
+      shortcutSpan.textContent = ''
     }
   }
 

--- a/lib/suggestion-list.js
+++ b/lib/suggestion-list.js
@@ -232,6 +232,12 @@ class SuggestionList {
     return (this.activeEditor != null)
   }
 
+  getSuggestionAtIndex (index) {
+    if (index >= 0 && index < this.items.length) {
+      return this.items[index]
+    }
+  }
+
   show (editor, options) {
     if (atom.config.get('autocomplete-plus.suggestionListFollows') === 'Cursor') {
       return this.showAtCursorPosition(editor, options)

--- a/lib/suggestion-shortcut.js
+++ b/lib/suggestion-shortcut.js
@@ -1,0 +1,31 @@
+'use babel'
+
+const MIN_INDEX = 1
+const MAX_INDEX = 9
+
+const CMD_PREFIX = 'autocomplete-plus:menu:'
+
+/**
+ * Create a notation from a key binding
+ * e.g. ctrl-a -> ^a
+ *      cmd-1  -> ⌘1 on mac
+ *             -> ^1 on PC
+ */
+let keystrokesToNotation = (keystrokes) => {
+  return keystrokes
+    .replace('cmd', process.platform === 'darwin' ? '⌘' : '^')
+    .replace('ctrl', '^')
+    .replace('-', '')
+}
+
+module.exports = {
+  getKeyStrokeNotation: (index) => {
+    if (index >= MIN_INDEX && index <= MAX_INDEX) {
+      let keys = atom.keymaps.findKeyBindings({command: CMD_PREFIX + index})
+      if (keys.length === 1) {
+        let {keystrokes} = keys[0]
+        return keystrokesToNotation(keystrokes)
+      }
+    }
+  }
+}

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -159,8 +159,23 @@ autocomplete-suggestion-list {
     }
   }
 
-  .word-container {
+  .shortcut {
     padding-right: @item-padding;
+    font-size: @font-size-small;
+    border-right: 1px solid @text-color-subtle;
+
+    &:empty {
+      padding-right: 0;
+      border-right: 0;
+    }
+
+    .icon-shortcut {
+      padding-right: 2px;
+    }
+  }
+
+  .word-container {
+    padding: 0 @item-padding;
   }
 
   .word {


### PR DESCRIPTION
_First time playing around with atom plugin, I'm not looking to merge this as it is, but mostly to get feedback_

### Description of the Change

The end goal of this is to add keybinding as Alfred does for quick selection (see ⌘2, ⌘3):
![image](https://user-images.githubusercontent.com/2635915/45362891-ff3e5b80-b5cd-11e8-82b5-ad2fe0815566.png) 
_(pressing cmd + 2 here would select and run "Search Amazon for 'autocomplete-plus'")_

This pull request is an attempt at doing that, the code is making some assumptions but it's usable.
![image](https://user-images.githubusercontent.com/2635915/45421439-efce1980-b684-11e8-9e0a-5fdc2ae9464e.png)


### Benefits

I often find myself typing extra character or using the arrows to navigate the suggestions list, this would allow users to select the suggestion they want to apply in fewer keystrokes.

### Alternate design
We can also have the shortcut to the right, but the drawbacks here is that it's get hidden if the suggestion is too wide.
![image](https://user-images.githubusercontent.com/2635915/45387740-e0ac8480-b60e-11e8-85f8-c150e33bae0c.png)


### Possible Drawbacks

We might want to disable this behaviour by default to not mess with existing user key mapping.


What do you guys think?