### PR TITLE
Allow numbers in prefix

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -515,7 +515,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     let regex = wordCharacterRegexCache.get(additionalWordChars)
 
     if (!regex) {
-      regex = new RegExp(`[${UnicodeLetters}${additionalWordChars.replace(']', '\\]')}]`)
+      regex = new RegExp(`[${UnicodeLetters}${additionalWordChars.replace(']', '\\]')}\\d]`)
       wordCharacterRegexCache.set(additionalWordChars, regex)
     }
     return regex

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -549,10 +549,9 @@ describe('Autocomplete Manager', () => {
       })
 
       it('calls with word prefix containing a number', () => {
-        editor.insertText('4okyea')
-        editor.insertText('h')
+        editor.insertText('4')
         waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc4okyeah'))
+        runs(() => expect(prefix).toBe('abc4'))
       })
 
       it('calls with space character', () => {

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -548,6 +548,13 @@ describe('Autocomplete Manager', () => {
         runs(() => expect(prefix).toBe('abc-okyeah'))
       })
 
+      it('calls with word prefix containing a number', () => {
+        editor.insertText('4okyea')
+        editor.insertText('h')
+        waitForAutocomplete()
+        runs(() => expect(prefix).toBe('abc4okyeah'))
+      })
+
       it('calls with space character', () => {
         editor.insertText(' ')
         waitForAutocomplete()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -549,9 +549,10 @@ describe('Autocomplete Manager', () => {
       })
 
       it('calls with word prefix containing a number', () => {
-        editor.insertText('4')
+        editor.insertText('4ok')
+        editor.insertText('5')
         waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc4'))
+        runs(() => expect(prefix).toBe('abc4ok5'))
       })
 
       it('calls with space character', () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Prevents the suggestion box hiding when a number is typed as part of the prefix

### Alternate Designs

NA

### Benefits

Allows numbers in prefixes to be typed

### Possible Drawbacks

NA

### Applicable Issues

Fixes #950 
Closes #979 
Fixes https://github.com/autocomplete-python/autocomplete-python/issues/364
Fixes https://github.com/autocomplete-python/autocomplete-python/issues/391


NOTE: I'm not sure if the tests are testing what I expect. It should though, because the change is to `getWordCharacterRegex`, which is used to get valid prefix characters, and the recognised prefix is then tested for.