### PR TITLE
Allow GitHub HTML tags in Markdown

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -3,7 +3,7 @@ const SnippetParser = require('./snippet-parser')
 const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const marked = require('marked')
-const sanitizeHtml = require('sanitize-html')
+const createDOMPurify = require('dompurify')
 
 const createSuggestionFrag = () => {
   const frag = document.createDocumentFragment()
@@ -137,7 +137,7 @@ module.exports = class SuggestionListElement {
 
     if (item.descriptionMarkdown && item.descriptionMarkdown.length > 0) {
       this.descriptionContainer.style.display = 'block'
-      this.descriptionContent.innerHTML = sanitizeHtml(
+      this.descriptionContent.innerHTML = createDOMPurify().sanitize(
         marked(item.descriptionMarkdown, {
           gfm: true,
           breaks: true,

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -3,6 +3,7 @@ const SnippetParser = require('./snippet-parser')
 const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const marked = require('marked')
+const sanitizeHtml = require('sanitize-html')
 
 const createSuggestionFrag = () => {
   const frag = document.createDocumentFragment()
@@ -136,7 +137,13 @@ module.exports = class SuggestionListElement {
 
     if (item.descriptionMarkdown && item.descriptionMarkdown.length > 0) {
       this.descriptionContainer.style.display = 'block'
-      this.descriptionContent.innerHTML = marked.parse(item.descriptionMarkdown, {sanitize: true})
+      this.descriptionContent.innerHTML = sanitizeHtml(
+        marked(item.descriptionMarkdown, {
+          gfm: true,
+          breaks: true,
+          sanitize: false
+        })
+      )
       this.setDescriptionMoreLink(item)
     } else if (item.description && item.description.length > 0) {
       this.descriptionContainer.style.display = 'block'

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.6.0",
     "grim": "^2.0.1",
-    "marked": "^0.3.17",
+    "marked": "^0.5.1",
     "minimatch": "^3.0.3",
+    "sanitize-html": "^1.19.1",
     "selector-kit": "^0.1",
     "stable": "^0.1.5",
     "underscore-plus": "^1.6.6"

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "atom-slick": "^2.0.0",
+    "dompurify": "^1.0.8",
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.6.0",
     "grim": "^2.0.1",
     "marked": "^0.5.1",
     "minimatch": "^3.0.3",
-    "sanitize-html": "^1.19.1",
     "selector-kit": "^0.1",
     "stable": "^0.1.5",
     "underscore-plus": "^1.6.6"


### PR DESCRIPTION
### Description of the Change

This pull request adds support for HTML tags in the description field. Only HTML tags in gfm (GitHub Flavored Markdown) are valid. This approach is heavily based on this piece of code:

https://github.com/sourcegraph/codeintellify/blob/5eef578cfc508dbcc6a97f5ba08675768b0a5187/src/helpers.ts#L90-L102

### Alternate Designs

Using the `dompurify` package instead of the `sanitize-html` package to be consistent with `markdown-preview` for example.

### Benefits

The description text in the LSP package `ide-php` contains HTML. This package currently sanitize the HTML which makes the description look like this:

<img width="544" src="https://user-images.githubusercontent.com/499192/48513926-74900c00-e85d-11e8-8b6a-6e632d159bc2.png">

With this update the description will instead look like this:

<img width="555" src="https://user-images.githubusercontent.com/499192/48513981-95f0f800-e85d-11e8-9e1c-eaf00ccf152c.png">

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/Microsoft/vscode/issues/40607
https://github.com/felixfbecker/php-language-server/issues/674
https://github.com/felixfbecker/php-language-server/issues/288
