### PR TITLE
Convert Provider API specs to async

### DIFF
--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -3,8 +3,8 @@
 
 const { TextEditor } = require('atom')
 const {
+  conditionPromise,
   triggerAutocompletion,
-  triggerAutocompletionPromise,
   waitForAutocomplete,
   waitForDeferredSuggestions,
   buildIMECompositionEvent
@@ -2549,7 +2549,10 @@ defm`
 
     it('provides appropriate autocompletions when each editor is focused.', async () => {
       bottomEditorView.focus()
-      await triggerAutocompletionPromise(bottomEditor)
+      triggerAutocompletion(bottomEditor)
+      await conditionPromise(
+        () => bottomEditorView.querySelectorAll('.autocomplete-plus li').length === 1
+      )
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -2558,7 +2561,10 @@ defm`
       expect(items[0].innerText.trim()).toEqual('bottom')
 
       editorView.focus()
-      await triggerAutocompletionPromise(editor)
+      triggerAutocompletion(editor)
+      await conditionPromise(
+        () => editorView.querySelectorAll('.autocomplete-plus li').length === 1
+      )
 
       expect(bottomEditorView.querySelector('.autocomplete-plus')).not.toExist()
 

--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -11,18 +11,11 @@ beforeEach(() => {
   atom.config.set('autocomplete-plus.includeCompletionsFromAllBuffers', false)
 })
 
-async function triggerAutocompletionPromise (editor, moveCursor = true, char = 'f') {
-  if (moveCursor) {
-    editor.moveToBottom()
-    editor.moveToBeginningOfLine()
-  }
-  editor.insertText(char)
-  module.exports.waitForAutocomplete()
-
+function waitForAutocompletePromise (editor) {
   const editorView = atom.views.getView(editor)
 
   return conditionPromise(
-    () => editorView.querySelectorAll('.autocomplete-plus li').length === 1
+    () => editorView.querySelectorAll('.autocomplete-plus').length === 1
   )
 }
 
@@ -32,7 +25,7 @@ let triggerAutocompletion = (editor, moveCursor = true, char = 'f') => {
     editor.moveToBeginningOfLine()
   }
   editor.insertText(char)
-  module.exports.waitForAutocomplete()
+  waitForAutocomplete()
 }
 
 let waitForAutocomplete = () => {
@@ -101,9 +94,10 @@ function timeoutPromise (timeout) {
 }
 
 module.exports = {
+  conditionPromise,
   triggerAutocompletion,
-  triggerAutocompletionPromise,
   waitForAutocomplete,
+  waitForAutocompletePromise,
   buildIMECompositionEvent,
   buildTextInputEvent,
   waitForDeferredSuggestions


### PR DESCRIPTION
This PR follows a similar approach than https://github.com/atom/autocomplete-plus/pull/1048 to make the specs more resilient by waiting for specific conditions instead of just sleeping some time.

Hopefully this will address the issue reported in https://github.com/atom/atom/issues/19478