### PR TITLE
Eliminate use of Jasmine 1.3 async helpers in favor of async/await

### DIFF
--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -1,37 +1,33 @@
 /* eslint-env jasmine */
 
-const { waitForAutocomplete, timeoutPromise } = require('./spec-helper')
+const { waitForAutocomplete, timeoutPromise, conditionPromise } = require('./spec-helper')
 
 describe('Async providers', () => {
   let completionDelay, editorView, editor, mainModule, autocompleteManager, registration
 
-  beforeEach(() => {
-    runs(() => {
-      // Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      atom.config.set('editor.fontSize', '16')
+  beforeEach(async () => {
+    jasmine.useRealClock()
 
-      // Set the completion delay
-      completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-      completionDelay += 100 // Rendering
+    // Set to live completion
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    atom.config.set('editor.fontSize', '16')
 
-      let workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
-    })
+    // Set the completion delay
+    completionDelay = 100
+    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
+    completionDelay += 100 // Rendering
 
-    waitsForPromise(() => atom.workspace.open('sample.js').then((e) => {
-      editor = e
-    }))
+    let workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
-    waitsForPromise(() => atom.packages.activatePackage('language-javascript'))
+    editor = await atom.workspace.open('sample.js')
+
+    await atom.packages.activatePackage('language-javascript')
 
     // Activate the package
-    waitsForPromise(() => atom.packages.activatePackage('autocomplete-plus').then((a) => {
-      mainModule = a.mainModule
-    }))
+    mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-    waitsFor(() => {
+    await conditionPromise(() => {
       autocompleteManager = mainModule.autocompleteManager
       return autocompleteManager
     })
@@ -65,7 +61,6 @@ describe('Async providers', () => {
     })
 
     it('should provide completions when a provider returns a promise that results in an array of suggestions', async () => {
-      jasmine.useRealClock()
       editor.moveToBottom()
       editor.insertText('o')
 
@@ -98,7 +93,6 @@ describe('Async providers', () => {
     })
 
     it('does not show the suggestion list when it is triggered then no longer needed', async () => {
-      jasmine.useRealClock()
       editorView = atom.views.getView(editor)
 
       editor.moveToBottom()

--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -3,7 +3,7 @@
 const { waitForAutocomplete, timeoutPromise, conditionPromise } = require('./spec-helper')
 
 describe('Async providers', () => {
-  let completionDelay, editorView, editor, mainModule, autocompleteManager, registration
+  let editorView, editor, mainModule, autocompleteManager, registration
 
   beforeEach(async () => {
     jasmine.useRealClock()
@@ -13,9 +13,7 @@ describe('Async providers', () => {
     atom.config.set('editor.fontSize', '16')
 
     // Set the completion delay
-    completionDelay = 100
-    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-    completionDelay += 100 // Rendering
+    atom.config.set('autocomplete-plus.autoActivationDelay', 100)
 
     let workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -4,114 +4,91 @@
 let temp = require('temp').track()
 import path from 'path'
 import fs from 'fs-plus'
+import { conditionPromise, waitForAutocomplete } from './spec-helper'
 
 describe('Autocomplete Manager', () => {
   let [directory, filePath, completionDelay, editorView, editor, mainModule, autocompleteManager, didAutocomplete] = []
 
-  beforeEach(() => {
-    runs(() => {
-      directory = temp.mkdirSync()
-      let sample = `var quicksort = function () {
-  var sort = function(items) {
-    if (items.length <= 1) return items;
-    var pivot = items.shift(), current, left = [], right = [];
-    while(items.length > 0) {
-      current = items.shift();
-      current < pivot ? left.push(current) : right.push(current);
-    }
-    return sort(left).concat(pivot).concat(sort(right));
-  };
+  beforeEach(async () => {
+    jasmine.useRealClock()
 
-  return sort(Array.apply(this, arguments));
+    directory = temp.mkdirSync()
+    let sample = `var quicksort = function () {
+var sort = function(items) {
+  if (items.length <= 1) return items;
+  var pivot = items.shift(), current, left = [], right = [];
+  while(items.length > 0) {
+    current = items.shift();
+    current < pivot ? left.push(current) : right.push(current);
+  }
+  return sort(left).concat(pivot).concat(sort(right));
+};
+
+return sort(Array.apply(this, arguments));
 };
 `
-      filePath = path.join(directory, 'sample.js')
-      fs.writeFileSync(filePath, sample)
+    filePath = path.join(directory, 'sample.js')
+    fs.writeFileSync(filePath, sample)
 
-      // Enable autosave
-      atom.config.set('autosave.enabled', true)
+    // Enable autosave
+    atom.config.set('autosave.enabled', true)
 
-      // Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      atom.config.set('editor.fontSize', '16')
+    // Set to live completion
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    atom.config.set('editor.fontSize', '16')
 
-      // Set the completion delay
-      completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-      completionDelay += 100 // Rendering
+    // Set the completion delay
+    completionDelay = 100
+    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
+    completionDelay += 100 // Rendering
 
-      let workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
-    })
+    let workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
-    waitsForPromise(() => atom.packages.activatePackage('autosave'))
+    await atom.packages.activatePackage('autosave')
 
-    waitsForPromise(() => atom.workspace.open(filePath).then((e) => {
-      editor = e
-      editorView = atom.views.getView(editor)
-    }))
+    editor = await atom.workspace.open(filePath)
+    editorView = atom.views.getView(editor)
 
-    waitsForPromise(() => atom.packages.activatePackage('language-javascript'))
+    await atom.packages.activatePackage('language-javascript')
 
     // Activate the package
-    waitsForPromise(() => atom.packages.activatePackage('autocomplete-plus').then((a) => {
-      mainModule = a.mainModule
-    }))
+    mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-    waitsFor(() => {
+    await conditionPromise(() => {
       if (!mainModule || !mainModule.autocompleteManager) {
         return false
       }
       return mainModule.autocompleteManager.ready
     })
 
-    runs(() => {
-      advanceClock(mainModule.autocompleteManager.providerManager.defaultProvider.deferBuildWordListInterval)
-      autocompleteManager = mainModule.autocompleteManager
-      let { displaySuggestions } = autocompleteManager
-      spyOn(autocompleteManager, 'displaySuggestions').andCallFake((suggestions, options) => {
-        displaySuggestions(suggestions, options)
-        didAutocomplete = true
-      })
+    autocompleteManager = mainModule.autocompleteManager
+    let { displaySuggestions } = autocompleteManager
+    spyOn(autocompleteManager, 'displaySuggestions').andCallFake((suggestions, options) => {
+      displaySuggestions(suggestions, options)
     })
   })
 
-  afterEach(() => {
-    didAutocomplete = false
-  })
-
   describe('autosave compatibility', () =>
-    it('keeps the suggestion list open while saving', () => {
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        // Trigger an autocompletion
-        editor.moveToBottom()
-        editor.moveToBeginningOfLine()
-        editor.insertText('f')
-        advanceClock(completionDelay)
-      })
+    it('keeps the suggestion list open while saving', async () => {
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+      // Trigger an autocompletion
+      editor.moveToBottom()
+      editor.moveToBeginningOfLine()
+      editor.insertText('f')
+      await waitForAutocomplete(editor)
 
-      waitsFor(() => didAutocomplete === true)
+      editor.save()
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      editor.insertText('u')
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        editor.save()
-        didAutocomplete = false
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        editor.insertText('u')
-        advanceClock(completionDelay)
-      })
-
-      waitsFor(() => didAutocomplete === true)
-
-      runs(() => {
-        editor.save()
-        didAutocomplete = false
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        // Accept suggestion
-        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        atom.commands.dispatch(suggestionListView.element, 'autocomplete-plus:confirm')
-        expect(editor.getBuffer().getLastLine()).toEqual('function')
-      })
+      editor.save()
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      // Accept suggestion
+      let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
+      atom.commands.dispatch(suggestionListView.element, 'autocomplete-plus:confirm')
+      expect(editor.getBuffer().getLastLine()).toEqual('function')
     })
   )
 })

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -7,7 +7,7 @@ import fs from 'fs-plus'
 import { conditionPromise, waitForAutocomplete } from './spec-helper'
 
 describe('Autocomplete Manager', () => {
-  let [directory, filePath, completionDelay, editorView, editor, mainModule, autocompleteManager, didAutocomplete] = []
+  let [directory, filePath, completionDelay, editorView, editor, mainModule, autocompleteManager] = []
 
   beforeEach(async () => {
     jasmine.useRealClock()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -2208,9 +2208,10 @@ defm`
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {data: 'i', target: activeElement}))
         triggerAutocompletion(editor, false, 'i')
 
-        await waitForAutocomplete(editor)
+        await conditionPromise(() =>
+          autocompleteManager.suggestionList.changeItems.callCount > 0
+        )
 
-        expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
         expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
         autocompleteManager.suggestionList.changeItems.reset()
 

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -4,8 +4,10 @@
 const { TextEditor } = require('atom')
 const {
   conditionPromise,
+  timeoutPromise,
   triggerAutocompletion,
   waitForAutocomplete,
+  waitForAutocompleteToDisappear,
   waitForDeferredSuggestions,
   buildIMECompositionEvent
 } = require('./spec-helper')
@@ -32,86 +34,74 @@ describe('Autocomplete Manager', () => {
   }
 
   beforeEach(() => {
+    jasmine.useRealClock()
     gutterWidth = null
-    runs(() => {
-      // Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      atom.config.set('editor.fontSize', '16')
+    // Set to live completion
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    atom.config.set('editor.fontSize', '16')
 
-      // Set the completion delay
-      completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-      completionDelay += 100 // Rendering
+    // Set the completion delay
+    completionDelay = 100
+    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
+    completionDelay += 100 // Rendering
 
-      workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
-      atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
-      atom.config.set('autocomplete-plus.consumeSuffix', true)
-    })
+    atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
+    atom.config.set('autocomplete-plus.consumeSuffix', true)
   })
 
   describe('when an external provider is registered', () => {
-    let [provider] = []
+    let provider
 
-    beforeEach(() => {
-      waitsForPromise(() =>
-        Promise.all([
-          atom.workspace.open('').then((e) => {
-            editor = e
-            editorView = atom.views.getView(editor)
-          }),
-          atom.packages.activatePackage('autocomplete-plus').then((a) => {
-            mainModule = a.mainModule
-          })
-        ]))
+    beforeEach(async () => {
+      editor = await atom.workspace.open('')
+      editorView = atom.views.getView(editor)
+      mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
+      await conditionPromise(() => mainModule.autocompleteManager)
 
-      waitsFor(() => mainModule.autocompleteManager)
-
-      runs(() => {
-        provider = {
-          scopeSelector: '*',
-          inclusionPriority: 2,
-          excludeLowerPriority: true,
-          getSuggestions ({prefix}) {
-            let list = ['ab', 'abc', 'abcd', 'abcde']
-            return (list.map((text) => ({text})))
-          }
+      provider = {
+        scopeSelector: '*',
+        inclusionPriority: 2,
+        excludeLowerPriority: true,
+        getSuggestions ({prefix}) {
+          let list = ['ab', 'abc', 'abcd', 'abcde']
+          return (list.map((text) => ({text})))
         }
-        mainModule.consumeProvider(provider, 3)
-      })
+      }
+      mainModule.consumeProvider(provider, 3)
     })
 
-    it("calls the provider's onDidInsertSuggestion method when it exists", () => {
+    it("calls the provider's onDidInsertSuggestion method when it exists", async () => {
       provider.onDidInsertSuggestion = jasmine.createSpy()
 
       triggerAutocompletion(editor, true, 'a')
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        let suggestion, triggerPosition
-        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+      let suggestion, triggerPosition
+      let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+      atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-        expect(provider.onDidInsertSuggestion).toHaveBeenCalled();
+      expect(provider.onDidInsertSuggestion).toHaveBeenCalled();
 
-        ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.mostRecentCall.args[0])
-        expect(editor).toBe(editor)
-        expect(triggerPosition).toEqual([0, 1])
-        expect(suggestion.text).toBe('ab')
-      })
+      ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.mostRecentCall.args[0])
+      expect(editor).toBe(editor)
+      expect(triggerPosition).toEqual([0, 1])
+      expect(suggestion.text).toBe('ab')
     })
 
-    it('closes the suggestion list when saving', () => {
+    it('closes the suggestion list when saving', async () => {
       let directory = temp.mkdirSync()
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
       editor.insertText('a')
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      waitsFor((done) => {
+      await new Promise((resolve) => {
         editor.getBuffer().onDidSave(() => {
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          done()
+          resolve()
         })
 
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
@@ -119,56 +109,50 @@ describe('Autocomplete Manager', () => {
       })
     })
 
-    it('does not show suggestions after a word has been confirmed', () => {
+    it('does not show suggestions after a word has been confirmed', async () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       for (let i = 0; i < 'red'.length; i++) { let c = 'red'[i]; editor.insertText(c) }
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-      })
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
     })
 
-    it('works after closing one of the copied tabs', () => {
+    it('works after closing one of the copied tabs', async () => {
       atom.workspace.paneForItem(editor).splitRight({copyActiveItem: true})
       atom.workspace.getActivePane().destroy()
 
       editor.insertNewline()
       editor.insertText('f')
 
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
     })
 
-    it('closes the suggestion list when entering an empty string (e.g. carriage return)', () => {
+    it('closes the suggestion list when entering an empty string (e.g. carriage return)', async () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       editor.insertText('a')
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        editor.insertText('\r')
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-      })
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      editor.insertText('\r')
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
     })
 
-    it('it refocuses the editor after pressing enter', () => {
+    it('it refocuses the editor after pressing enter', async () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       editor.insertText('a')
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        editor.insertText('\n')
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        expect(editorView).toHaveFocus()
-      })
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      editor.insertText('\n')
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+      expect(editorView).toHaveFocus()
     })
 
-    it('it hides the suggestion list when the user keeps typing', () => {
+    it('it hides the suggestion list when the user keeps typing', async () => {
       spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -176,27 +160,21 @@ describe('Autocomplete Manager', () => {
       // Trigger an autocompletion
       editor.moveToBottom()
       editor.insertText('a')
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-        editor.insertText('b')
-        waitForAutocomplete()
-      })
-
-      runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+      editor.insertText('b')
+      await waitForAutocompleteToDisappear(editor)
     })
 
-    it('does not show the suggestion list when pasting', () => {
+    it('does not show the suggestion list when pasting', async () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       editor.insertText('red')
-      waitForAutocomplete()
-
-      runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+      await waitForAutocompleteToDisappear(editor)
     })
 
-    it('only shows for the editor that currently has focus', () => {
+    it('only shows for the editor that currently has focus', async () => {
       let editor2 = atom.workspace.paneForItem(editor).splitRight({copyActiveItem: true}).getActiveItem()
       let editorView2 = atom.views.getView(editor2)
       editorView.focus()
@@ -212,26 +190,24 @@ describe('Autocomplete Manager', () => {
       expect(editorView).toHaveFocus()
       expect(editorView2).not.toHaveFocus()
 
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView).toHaveFocus()
-        expect(editorView2).not.toHaveFocus()
+      expect(editorView).toHaveFocus()
+      expect(editorView2).not.toHaveFocus()
 
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView2.querySelector('.autocomplete-plus')).not.toExist()
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      expect(editorView2.querySelector('.autocomplete-plus')).not.toExist()
 
-        atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+      atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
 
-        expect(editorView).toHaveFocus()
-        expect(editorView2).not.toHaveFocus()
+      expect(editorView).toHaveFocus()
+      expect(editorView2).not.toHaveFocus()
 
-        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        expect(editorView2.querySelector('.autocomplete-plus')).not.toExist()
-      })
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+      expect(editorView2.querySelector('.autocomplete-plus')).not.toExist()
     })
 
-    it('does not display empty suggestions', () => {
+    it('does not display empty suggestions', async () => {
       spyOn(provider, 'getSuggestions').andCallFake(() => {
         let list = ['ab', '', 'abcd', null]
         return (list.map((text) => ({text})))
@@ -239,12 +215,10 @@ describe('Autocomplete Manager', () => {
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       editor.insertText('a')
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
-      })
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
     })
 
     describe('when the fileBlacklist option is set', () => {
@@ -253,57 +227,38 @@ describe('Autocomplete Manager', () => {
         editor.getBuffer().setPath('blacklisted.md')
       })
 
-      it('does not show suggestions when working with files that match the blacklist', () => {
+      it('does not show suggestions when working with files that match the blacklist', async () => {
         editor.insertText('a')
-        waitForAutocomplete()
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('caches the blacklist result', () => {
+      it('caches the blacklist result', async () => {
         spyOn(path, 'basename').andCallThrough()
 
         editor.insertText('a')
-        waitForAutocomplete()
+        editor.insertText('b')
+        editor.insertText('c')
 
-        runs(() => {
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          editor.insertText('c')
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          expect(path.basename.callCount).toBe(1)
-        })
+        await waitForAutocompleteToDisappear(editor)
+        expect(path.basename.callCount).toBe(1)
       })
 
-      it('shows suggestions when the path is changed to not match the blacklist', () => {
+      it('shows suggestions when the path is changed to not match the blacklist', async () => {
         editor.insertText('a')
-        waitForAutocomplete()
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
+        await waitForAutocompleteToDisappear(editor)
+        atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
 
-          editor.getBuffer().setPath('not-blackslisted.txt')
-          editor.insertText('a')
-          waitForAutocomplete()
-        })
+        editor.getBuffer().setPath('not-blackslisted.txt')
+        editor.insertText('a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
 
-          editor.getBuffer().setPath('blackslisted.md')
-          editor.insertText('a')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        editor.getBuffer().setPath('blackslisted.md')
+        editor.insertText('a')
+        await waitForAutocompleteToDisappear(editor)
       })
     })
 
@@ -317,13 +272,14 @@ describe('Autocomplete Manager', () => {
 
           getSuggestions ({prefix}) {
             let list = ['ab', 'abc', 'abcd', 'abcde']
+
             return (list.map((text) => ({text})))
           }
         }
         mainModule.consumeProvider(provider)
       })
 
-      it('does not display empty suggestions', () => {
+      it('does not display empty suggestions', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => {
           let list = ['ab', '', 'abcd', null]
           return (list.map((text) => ({text})))
@@ -331,84 +287,76 @@ describe('Autocomplete Manager', () => {
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
       })
     })
 
     describe('when the type option has a space in it', () =>
-      it('does not display empty suggestions', () => {
+      it('does not display empty suggestions', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', type: 'local function'}, {text: 'abc', type: ' another ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          let items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items).toHaveLength(2)
-          expect(items[0].querySelector('.icon').className).toBe('icon local function')
-          expect(items[1].querySelector('.icon').className).toBe('icon another ~ function')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        let items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items).toHaveLength(2)
+        expect(items[0].querySelector('.icon').className).toBe('icon local function')
+        expect(items[1].querySelector('.icon').className).toBe('icon another ~ function')
       })
     )
 
     describe('when the className option has a space in it', () =>
-      it('does not display empty suggestions', () => {
+      it('does not display empty suggestions', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', className: 'local function'}, {text: 'abc', className: ' another  ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          let items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0].className).toBe('selected local function')
-          expect(items[1].className).toBe('another ~ function')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        let items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0].className).toBe('selected local function')
+        expect(items[1].className).toBe('another ~ function')
       })
     )
 
     describe('when multiple cursors are defined', () => {
-      it('autocompletes word when there is only a prefix', () => {
+      it('autocompletes word when there is only a prefix', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'shift'}])
 
         editor.getBuffer().insert([0, 0], 's:extra:s')
         editor.setSelectedBufferRanges([[[0, 1], [0, 1]], [[0, 9], [0, 9]]])
         triggerAutocompletion(editor, false, 'h')
 
-        waits(completionDelay)
+        await waitForAutocomplete(editor);
 
-        runs(() => {
-          ({ autocompleteManager } = mainModule)
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        ({ autocompleteManager } = mainModule)
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+        atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
 
-          expect(editor.lineTextForBufferRow(0)).toBe('shift:extra:shift')
-          expect(editor.getCursorBufferPosition()).toEqual([0, 17])
-          expect(editor.getLastSelection().getBufferRange()).toEqual({
-            start: {
-              row: 0,
-              column: 17
-            },
-            end: {
-              row: 0,
-              column: 17
-            }
-          })
-
-          expect(editor.getSelections().length).toEqual(2)
+        expect(editor.lineTextForBufferRow(0)).toBe('shift:extra:shift')
+        expect(editor.getCursorBufferPosition()).toEqual([0, 17])
+        expect(editor.getLastSelection().getBufferRange()).toEqual({
+          start: {
+            row: 0,
+            column: 17
+          },
+          end: {
+            row: 0,
+            column: 17
+          }
         })
+
+        expect(editor.getSelections().length).toEqual(2)
       })
 
-      it('cancels the autocomplete when text differs between cursors', () => {
+      it('cancels the autocomplete when text differs between cursors', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [])
 
         editor.getBuffer().insert([0, 0], 's:extra:a')
@@ -416,187 +364,184 @@ describe('Autocomplete Manager', () => {
         editor.addCursorAtBufferPosition([0, 9])
         triggerAutocompletion(editor, false, 'h')
 
-        waits(completionDelay)
+        ;({ autocompleteManager } = mainModule)
+        editorView = atom.views.getView(editor)
+        atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
 
-        runs(() => {
-          ({ autocompleteManager } = mainModule)
-          editorView = atom.views.getView(editor)
-          atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+        expect(editor.lineTextForBufferRow(0)).toBe('sh:extra:ah')
+        expect(editor.getSelections().length).toEqual(2)
+        expect(editor.getSelections()[0].getBufferRange()).toEqual([[0, 2], [0, 2]])
+        expect(editor.getSelections()[1].getBufferRange()).toEqual([[0, 11], [0, 11]])
 
-          expect(editor.lineTextForBufferRow(0)).toBe('sh:extra:ah')
-          expect(editor.getSelections().length).toEqual(2)
-          expect(editor.getSelections()[0].getBufferRange()).toEqual([[0, 2], [0, 2]])
-          expect(editor.getSelections()[1].getBufferRange()).toEqual([[0, 11], [0, 11]])
-
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        })
+        await waitForAutocompleteToDisappear(editor)
       })
     })
 
     describe('suppression for editorView classes', () => {
-      beforeEach(() => atom.config.set('autocomplete-plus.suppressActivationForEditorClasses', ['vim-mode.command-mode', 'vim-mode . visual-mode', ' vim-mode.operator-pending-mode ', ' ']))
-
-      it('should show the suggestion list when the suppression list does not match', () => {
-        runs(() => {
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('insert-mode')
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+      beforeEach(() => {
+        atom.config.set(
+          'autocomplete-plus.suppressActivationForEditorClasses',
+          ['vim-mode.command-mode', 'vim-mode . visual-mode', ' vim-mode.operator-pending-mode ', ' ']
+        )
       })
 
-      it('should not show the suggestion list when the suppression list does match', () => {
-        runs(() => {
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('command-mode')
-        })
+      it('should show the suggestion list when the suppression list does not match', async () => {
+        editorView.classList.add('vim-mode')
+        editorView.classList.add('insert-mode')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocomplete(editor)
 
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
       })
 
-      it('should not show the suggestion list when the suppression list does match', () => {
-        runs(() => {
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('operator-pending-mode')
-        })
+      it('should not show the suggestion list when the suppression list does match', async () => {
+        editorView.classList.add('vim-mode')
+        editorView.classList.add('command-mode')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('should not show the suggestion list when the suppression list does match', () => {
-        runs(() => {
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('visual-mode')
-        })
+      it('should not show the suggestion list when the suppression list does match', async () => {
+        editorView.classList.add('vim-mode')
+        editorView.classList.add('operator-pending-mode')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('should show the suggestion list when the suppression list does not match', () => {
-        runs(() => {
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('some-unforeseen-mode')
-        })
+      it('should not show the suggestion list when the suppression list does match', async () => {
+        editorView.classList.add('vim-mode')
+        editorView.classList.add('visual-mode')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('should show the suggestion list when the suppression list does not match', () => {
-        runs(() => editorView.classList.add('command-mode'))
+      it('should show the suggestion list when the suppression list does not match', async () => {
+        editorView.classList.add('vim-mode')
+        editorView.classList.add('some-unforeseen-mode')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          triggerAutocompletion(editor)
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocomplete(editor)
 
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      })
+
+      it('should show the suggestion list when the suppression list does not match', async () => {
+        editorView.classList.add('command-mode')
+
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        triggerAutocompletion(editor)
+        await waitForAutocomplete(editor)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
       })
     })
 
     describe('prefix passed to getSuggestions', () => {
       let prefix = null
+      let suggestionsPromise
+
       beforeEach(() => {
+        let resolveSuggestionsPromise
+        suggestionsPromise = new Promise(resolve => {
+          resolveSuggestionsPromise = resolve
+        })
+
         editor.setText('var something = abc')
         editor.setCursorBufferPosition([0, 10000])
         spyOn(provider, 'getSuggestions').andCallFake((options) => {
           prefix = options.prefix
+          resolveSuggestionsPromise()
           return []
         })
       })
 
-      it('calls with word prefix', () => {
+      it('calls with word prefix', async () => {
         editor.insertText('d')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abcd'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('abcd')
       })
 
-      it('calls with word prefix after punctuation', () => {
+      it('calls with word prefix after punctuation', async () => {
         editor.insertText('d.okyea')
         editor.insertText('h')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('okyeah'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('okyeah')
       })
 
-      it('calls with word prefix containing a dash', () => {
+      it('calls with word prefix containing a dash', async () => {
         editor.insertText('-okyea')
         editor.insertText('h')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc-okyeah'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('abc-okyeah')
       })
 
-      it('calls with word prefix containing a number', () => {
+      it('calls with word prefix containing a number', async () => {
         editor.insertText('4ok')
         editor.insertText('5')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('abc4ok5'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('abc4ok5')
       })
 
-      it('calls with space character', () => {
+      it('calls with space character', async () => {
         editor.insertText(' ')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe(' '))
+        await suggestionsPromise
+
+        expect(prefix).toBe(' ')
       })
 
-      it('calls with non-word prefix', () => {
+      it('calls with non-word prefix', async () => {
         editor.insertText(':')
         editor.insertText(':')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('::'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('::')
       })
 
-      it('calls with non-word bracket', () => {
+      it('calls with non-word bracket', async () => {
         editor.insertText('[')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('['))
+        await suggestionsPromise
+
+        expect(prefix).toBe('[')
       })
 
-      it('calls with dot prefix', () => {
+      it('calls with dot prefix', async () => {
         editor.insertText('.')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe('.'))
+        await suggestionsPromise
+
+        expect(prefix).toBe('.')
       })
 
-      it('calls with prefix after non \\b word break', () => {
+      it('calls with prefix after non \\b word break', async () => {
         editor.insertText('=""')
         editor.insertText(' ')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe(' '))
+        await suggestionsPromise
+
+        expect(prefix).toBe(' ')
       })
 
-      it('calls with prefix after non \\b word break', () => {
+      it('calls with prefix after non \\b word break', async () => {
         editor.insertText('?')
         editor.insertText(' ')
-        waitForAutocomplete()
-        runs(() => expect(prefix).toBe(' '))
+        await suggestionsPromise
+
+        expect(prefix).toBe(' ')
       })
 
       describe('providers using the 4.0 API', () => {
-        it('accounts for word characters of the current language', () => {
+        it('accounts for word characters of the current language', async () => {
           let prefix = null
           const provider = {
             scopeSelector: '*',
@@ -610,11 +555,12 @@ describe('Autocomplete Manager', () => {
           atom.config.set('editor.nonWordCharacters', '-')
           editor.insertText(' $foo-$ba')
           editor.insertText('r')
-          waitForAutocomplete()
-          runs(() => expect(prefix).toBe('$bar'))
+          await suggestionsPromise
+
+          expect(prefix).toBe('$bar')
         })
 
-        it('is an empty string when the cursor does not follow a word character', () => {
+        it('is an empty string when the cursor does not follow a word character', async () => {
           let prefix = null
           const provider = {
             scopeSelector: '*',
@@ -626,40 +572,37 @@ describe('Autocomplete Manager', () => {
           mainModule.consumeProvider(provider, 4)
           editor.insertText(' foo')
           editor.insertText('.')
-          waitForAutocomplete()
-          runs(() => expect(prefix).toBe(''))
+          await suggestionsPromise
+
+          expect(prefix).toBe('')
         })
       })
     })
 
     describe('when the character entered is not at the cursor position', () => {
-      it('does not show the suggestion list', () => {
+      it('does not show the suggestion list', async () => {
         editor.setText('some text ok')
         editor.setCursorBufferPosition([0, 7])
 
         let buffer = editor.getBuffer()
         buffer.setTextInRange([[0, 0], [0, 0]], 's')
-        waitForAutocomplete()
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('does not hide the suggestion list', () => {
+      it('does not hide the suggestion list', async () => {
         editor.setText(
           '0\n' +
           '1\n'
         )
         editor.setCursorBufferPosition([2, 0])
         editor.insertText('2')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.setTextInBufferRange([[0, 0], [0, 0]], '*')
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.setTextInBufferRange([[0, 0], [0, 0]], '\n')
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        editor.setTextInBufferRange([[0, 0], [0, 0]], '*')
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        editor.setTextInBufferRange([[0, 0], [0, 0]], '\n')
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
       })
     })
 
@@ -669,12 +612,13 @@ describe('Autocomplete Manager', () => {
       })
 
       describe('when a suggestion description is not specified', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           triggerAutocompletion(editor, true, 'a')
-          waitForDeferredSuggestions(editorView, 4)
+          await waitForAutocomplete(editor)
+          await waitForDeferredSuggestions(editorView, 4)
         })
 
-        it('scrolls the list always showing the selected item', () => {
+        it('scrolls the list always showing the selected item', async () => {
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
           let itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
 
@@ -777,29 +721,27 @@ describe('Autocomplete Manager', () => {
       })
 
       describe('when a suggestion description is specified', () => {
-        it('shows the maxVisibleSuggestions in the suggestion popup, but with extra height for the description', () => {
+        it('shows the maxVisibleSuggestions in the suggestion popup, but with extra height for the description', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(() => {
             let list = ['ab', 'abc', 'abcd', 'abcde']
             return (list.map((text) => ({text, description: `${text} yeah ok`})))
           })
 
           triggerAutocompletion(editor, true, 'a')
+          await waitForAutocomplete(editor)
+          await waitForDeferredSuggestions(editorView, 4)
 
-          waitForDeferredSuggestions(editorView, 4)
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          let itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
+          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(4)
 
-          runs(() => {
-            expect(editorView.querySelector('.autocomplete-plus')).toExist()
-            let itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
-            expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(4)
-
-            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            let descriptionHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus .suggestion-description')).height)
-            expect(suggestionList.offsetHeight).toBe((2 * itemHeight) + descriptionHeight)
-            expect(suggestionList.querySelector('.suggestion-list-scroller').style['max-height']).toBe(`${2 * itemHeight}px`)
-          })
+          let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          let descriptionHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus .suggestion-description')).height)
+          expect(suggestionList.offsetHeight).toBe((2 * itemHeight) + descriptionHeight)
+          expect(suggestionList.querySelector('.suggestion-list-scroller').style['max-height']).toBe(`${2 * itemHeight}px`)
         })
 
-        it('parses markdown in the description', () => {
+        it('parses markdown in the description', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
             let list = [
               {text: 'ab', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmmmmmm**'},
@@ -811,29 +753,25 @@ describe('Autocomplete Manager', () => {
           })
 
           triggerAutocompletion(editor, true, 'a')
+          await waitForAutocomplete(editor)
+          await waitForDeferredSuggestions(editorView, 4)
 
-          waitForDeferredSuggestions(editorView, 4)
+          let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          expect(suggestionList).toExist()
 
-          runs(() => {
-            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            expect(suggestionList).toExist()
+          expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmmmmmm')
 
-            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmmmmmm')
+          editor.insertText('b')
+          editor.insertText('c')
+          await waitForAutocomplete(editor)
 
-            editor.insertText('b')
-            editor.insertText('c')
-            waitForAutocomplete()
-          })
+          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          expect(suggestionList).toExist()
 
-          runs(() => {
-            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            expect(suggestionList).toExist()
-
-            expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmm')
-          })
+          expect(editorView.querySelector('.autocomplete-plus .suggestion-description strong').textContent).toEqual('mmmmmmmmmmmmmmmmmmmmmm')
         })
 
-        it('adjusts the width when the description changes', () => {
+        it('adjusts the width when the description changes', async () => {
           let listWidth = null
           spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
             let list = [
@@ -846,29 +784,25 @@ describe('Autocomplete Manager', () => {
           })
 
           triggerAutocompletion(editor, true, 'a')
+          await waitForAutocomplete(editor)
+          await waitForDeferredSuggestions(editorView, 4)
 
-          waitForDeferredSuggestions(editorView, 4)
+          let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          expect(suggestionList).toExist()
 
-          runs(() => {
-            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            expect(suggestionList).toExist()
+          listWidth = parseInt(suggestionList.style.width)
+          expect(listWidth).toBeGreaterThan(0)
 
-            listWidth = parseInt(suggestionList.style.width)
-            expect(listWidth).toBeGreaterThan(0)
+          editor.insertText('b')
+          editor.insertText('c')
+          await waitForAutocomplete(editor)
 
-            editor.insertText('b')
-            editor.insertText('c')
-            waitForAutocomplete()
-          })
+          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          expect(suggestionList).toExist()
 
-          runs(() => {
-            let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            expect(suggestionList).toExist()
-
-            let newWidth = parseInt(suggestionList.style.width)
-            expect(newWidth).toBeGreaterThan(0)
-            expect(newWidth).toBeLessThan(listWidth)
-          })
+          let newWidth = parseInt(suggestionList.style.width)
+          expect(newWidth).toBeGreaterThan(0)
+          expect(newWidth).toBeLessThan(listWidth)
         })
       })
     })
@@ -876,13 +810,12 @@ describe('Autocomplete Manager', () => {
     describe('when useCoreMovementCommands is toggled', () => {
       let [suggestionList] = []
 
-      beforeEach(() => {
+      beforeEach(async () => {
         triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
       })
 
       it('binds to custom commands when unset, and binds back to core commands when set', () => {
@@ -908,14 +841,13 @@ describe('Autocomplete Manager', () => {
     describe('when useCoreMovementCommands is false', () => {
       let [suggestionList] = []
 
-      beforeEach(() => {
+      beforeEach(async () => {
         atom.config.set('autocomplete-plus.useCoreMovementCommands', false)
         triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
       })
 
       it('responds to all the custom movement commands and to no core commands', () => {
@@ -943,66 +875,61 @@ describe('Autocomplete Manager', () => {
     })
 
     describe('when match.snippet is used', () => {
-      beforeEach(() =>
+      beforeEach(() => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
           let list = ['method(${1:something})', 'method2(${1:something})', 'method3(${1:something})', 'namespace\\\\method4(${1:something})']
           return (list.map((snippet) => ({snippet, replacementPrefix: prefix})))
         })
-      )
+      })
 
       describe('when the snippets package is enabled', () => {
-        beforeEach(() =>
-          waitsForPromise(() => atom.packages.activatePackage('snippets'))
-        )
+        beforeEach(() => atom.packages.activatePackage('snippets'))
 
-        it('displays the snippet without the `${1:}` in its own class', () => {
+        it('displays the snippet without the `${1:}` in its own class', async () => {
           triggerAutocompletion(editor, true, 'm')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let wordElement = editorView.querySelector('.autocomplete-plus span.word')
-            expect(wordElement.textContent).toBe('method(something)')
-            expect(wordElement.querySelector('.snippet-completion').textContent).toBe('something')
+          let wordElement = editorView.querySelector('.autocomplete-plus span.word')
+          expect(wordElement.textContent).toBe('method(something)')
+          expect(wordElement.querySelector('.snippet-completion').textContent).toBe('something')
 
-            let wordElements = editorView.querySelectorAll('.autocomplete-plus span.word')
-            expect(wordElements).toHaveLength(4)
-          })
+          let wordElements = editorView.querySelectorAll('.autocomplete-plus span.word')
+          expect(wordElements).toHaveLength(4)
         })
 
-        it('accepts the snippet when autocomplete-plus:confirm is triggered', () => {
+        it('accepts the snippet when autocomplete-plus:confirm is triggered', async () => {
           triggerAutocompletion(editor, true, 'm')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-            expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-            expect(editor.getSelectedText()).toBe('something')
-          })
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          expect(editor.getSelectedText()).toBe('something')
         })
 
-        it('escapes \\ in list to match snippet behavior', () => {
+        it('escapes \\ in list to match snippet behavior', async () => {
           triggerAutocompletion(editor, true, 'm')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            // Value in list
-            let wordElements = editorView.querySelectorAll('.autocomplete-plus span.word')
-            expect(wordElements).toHaveLength(4)
-            expect(wordElements[3].textContent).toBe('namespace\\method4(something)')
+          // Value in list
+          let wordElements = editorView.querySelectorAll('.autocomplete-plus span.word')
+          expect(wordElements).toHaveLength(4)
+          expect(wordElements[3].textContent).toBe('namespace\\method4(something)')
 
-            // Select last item
-            atom.commands.dispatch(editorView, 'core:move-up')
+          // Select last item
+          atom.commands.dispatch(editorView, 'core:move-up')
 
-            // Value in editor
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-            expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-            expect(editor.getText()).toBe('namespace\\method4(something)')
-          })
+          // Value in editor
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          expect(editor.getText()).toBe('namespace\\method4(something)')
         })
       })
     })
 
     describe('when the matched prefix is highlighted', () => {
-      it('highlights the prefix of the word in the suggestion list', () => {
+      it('highlights the prefix of the word in the suggestion list', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'items', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -1012,22 +939,20 @@ describe('Autocomplete Manager', () => {
         editor.insertText('e')
         editor.insertText('m')
 
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          let word = editorView.querySelector('.autocomplete-plus li span.word')
-          expect(word.childNodes).toHaveLength(5)
-          expect(word.childNodes[0]).toHaveClass('character-match')
-          expect(word.childNodes[1].nodeType).toBe(NodeTypeText)
-          expect(word.childNodes[2]).toHaveClass('character-match')
-          expect(word.childNodes[3]).toHaveClass('character-match')
-          expect(word.childNodes[4].nodeType).toBe(NodeTypeText)
-        })
+        let word = editorView.querySelector('.autocomplete-plus li span.word')
+        expect(word.childNodes).toHaveLength(5)
+        expect(word.childNodes[0]).toHaveClass('character-match')
+        expect(word.childNodes[1].nodeType).toBe(NodeTypeText)
+        expect(word.childNodes[2]).toHaveClass('character-match')
+        expect(word.childNodes[3]).toHaveClass('character-match')
+        expect(word.childNodes[4].nodeType).toBe(NodeTypeText)
       })
 
-      it('highlights repeated characters in the prefix', () => {
+      it('highlights repeated characters in the prefix', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'apply', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -1037,23 +962,21 @@ describe('Autocomplete Manager', () => {
         editor.insertText('p')
         editor.insertText('p')
 
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          let word = editorView.querySelector('.autocomplete-plus li span.word')
-          expect(word.childNodes).toHaveLength(4)
-          expect(word.childNodes[0]).toHaveClass('character-match')
-          expect(word.childNodes[1]).toHaveClass('character-match')
-          expect(word.childNodes[2]).toHaveClass('character-match')
-          expect(word.childNodes[3].nodeType).toBe(3) // text
-          expect(word.childNodes[3].textContent).toBe('ly')
-        })
+        let word = editorView.querySelector('.autocomplete-plus li span.word')
+        expect(word.childNodes).toHaveLength(4)
+        expect(word.childNodes[0]).toHaveClass('character-match')
+        expect(word.childNodes[1]).toHaveClass('character-match')
+        expect(word.childNodes[2]).toHaveClass('character-match')
+        expect(word.childNodes[3].nodeType).toBe(3) // text
+        expect(word.childNodes[3].textContent).toBe('ly')
       })
 
       describe('when the prefix does not match the word', () => {
-        it('does not render any character-match spans', () => {
+        it('does not render any character-match spans', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'omgnope', replacementPrefix: prefix}])
 
           editor.moveToBottom()
@@ -1061,98 +984,90 @@ describe('Autocomplete Manager', () => {
           editor.insertText('y')
           editor.insertText('z')
 
-          waitForAutocomplete()
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-            let characterMatches = editorView.querySelectorAll('.autocomplete-plus li span.word .character-match')
-            let text = editorView.querySelector('.autocomplete-plus li span.word').textContent
-            expect(characterMatches).toHaveLength(0)
-            expect(text).toBe('omgnope')
-          })
+          let characterMatches = editorView.querySelectorAll('.autocomplete-plus li span.word .character-match')
+          let text = editorView.querySelector('.autocomplete-plus li span.word').textContent
+          expect(characterMatches).toHaveLength(0)
+          expect(text).toBe('omgnope')
         })
 
         describe('when the snippets package is enabled', () => {
-          beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('snippets')))
+          beforeEach(() => atom.packages.activatePackage('snippets'))
 
-          it('does not highlight the snippet html; ref issue 301', () => {
+          it('does not highlight the snippet html; ref issue 301', async () => {
             spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ab(${1:c})c'}])
 
             editor.moveToBottom()
             editor.insertText('c')
-            waitForAutocomplete()
+            await waitForAutocomplete(editor)
 
-            runs(() => {
-              let word = editorView.querySelector('.autocomplete-plus li span.word')
-              let charMatch = editorView.querySelector('.autocomplete-plus li span.word .character-match')
-              expect(word.textContent).toBe('ab(c)c')
-              expect(charMatch.textContent).toBe('c')
-              expect(charMatch.parentNode).toHaveClass('snippet-completion')
-            })
+            let word = editorView.querySelector('.autocomplete-plus li span.word')
+            let charMatch = editorView.querySelector('.autocomplete-plus li span.word .character-match')
+            expect(word.textContent).toBe('ab(c)c')
+            expect(charMatch.textContent).toBe('c')
+            expect(charMatch.parentNode).toHaveClass('snippet-completion')
           })
 
-          it('does not highlight the snippet html when highlight beginning of the word', () => {
+          it('does not highlight the snippet html when highlight beginning of the word', async () => {
             spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'abcde(${1:e}, ${1:f})f'}])
 
             editor.moveToBottom()
             editor.insertText('c')
             editor.insertText('e')
             editor.insertText('f')
-            waitForAutocomplete()
+            await waitForAutocomplete(editor)
 
-            runs(() => {
-              let word = editorView.querySelector('.autocomplete-plus li span.word')
-              expect(word.textContent).toBe('abcde(e, f)f')
+            let word = editorView.querySelector('.autocomplete-plus li span.word')
+            expect(word.textContent).toBe('abcde(e, f)f')
 
-              let charMatches = editorView.querySelectorAll('.autocomplete-plus li span.word .character-match')
-              expect(charMatches[0].textContent).toBe('c')
-              expect(charMatches[0].parentNode).toHaveClass('word')
-              expect(charMatches[1].textContent).toBe('e')
-              expect(charMatches[1].parentNode).toHaveClass('word')
-              expect(charMatches[2].textContent).toBe('f')
-              expect(charMatches[2].parentNode).toHaveClass('snippet-completion')
-            })
+            let charMatches = editorView.querySelectorAll('.autocomplete-plus li span.word .character-match')
+            expect(charMatches[0].textContent).toBe('c')
+            expect(charMatches[0].parentNode).toHaveClass('word')
+            expect(charMatches[1].textContent).toBe('e')
+            expect(charMatches[1].parentNode).toHaveClass('word')
+            expect(charMatches[2].textContent).toBe('f')
+            expect(charMatches[2].parentNode).toHaveClass('snippet-completion')
           })
         })
       })
     })
 
     describe('when a replacementPrefix is not specified', () => {
-      beforeEach(() =>
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something'}]))
+      beforeEach(() => {
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something'}])
+      })
 
-      it('replaces with the default input prefix', () => {
+      it('replaces with the default input prefix', async () => {
         editor.insertText('abc')
         triggerAutocompletion(editor, false, 'm')
+        await waitForAutocomplete(editor)
 
         expect(editor.getText()).toBe('abcm')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-          expect(editor.getText()).toBe('something')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        expect(editor.getText()).toBe('something')
       })
 
-      it('does not replace non-word prefixes with the chosen suggestion', () => {
+      it('does not replace non-word prefixes with the chosen suggestion', async () => {
         editor.insertText('abc')
         editor.insertText('.')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
         expect(editor.getText()).toBe('abc.')
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-          expect(editor.getText()).toBe('abc.something')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        expect(editor.getText()).toBe('abc.something')
       })
 
       describe('providers using the 4.0 API', () => {
-        it('replaces the entire prefix by default, regardless of the characters it contains', () => {
+        it('replaces the entire prefix by default, regardless of the characters it contains', async () => {
           atom.config.set('editor.nonWordCharacters', '-')
           provider = {
             scopeSelector: '*',
@@ -1169,14 +1084,12 @@ describe('Autocomplete Manager', () => {
           editor.setText('')
           editor.insertText('$food $fo')
           editor.insertText('o')
-          waitForAutocomplete()
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            expect(editorView.querySelector('.autocomplete-plus')).toExist()
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-            expect(editor.getText()).toBe('$food $food')
-          })
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          expect(editor.getText()).toBe('$food $food')
         })
       })
     })
@@ -1188,56 +1101,56 @@ describe('Autocomplete Manager', () => {
       // Mutable suggestion
       let suggestion = {text: 'something'}
 
-      beforeEach(() =>
-        spyOn(provider, 'getSuggestions').andCallFake(() => [suggestion]))
-
-      it('adds isPrefixModified the first time suggestion is shown', () => {
-        editor.insertText('so')
-        triggerAutocompletion(editor, false, 'm')
-
-        runs(() => {
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-          expect(editor.getText()).toBe('something')
-          expect(suggestion.replacementPrefix).toBe('som')
-          expect(suggestion.isPrefixModified).toBe(true)
-        })
+      beforeEach(() => {
+        spyOn(provider, 'getSuggestions').andCallFake(() => [suggestion])
       })
 
-      it('updates replacementPrefix when returning the same suggestion', () => {
+      it('adds isPrefixModified the first time suggestion is shown', async () => {
+        editor.insertText('so')
+        triggerAutocompletion(editor, false, 'm')
+        await waitForAutocomplete(editor)
+
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        expect(editor.getText()).toBe('something')
+        expect(suggestion.replacementPrefix).toBe('som')
+        expect(suggestion.isPrefixModified).toBe(true)
+      })
+
+      it('updates replacementPrefix when returning the same suggestion', async () => {
         editor.insertText('some')
         triggerAutocompletion(editor, false, 't')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-          expect(editor.getText()).toBe('something')
-          expect(suggestion.replacementPrefix).toBe('somet')
-          expect(suggestion.isPrefixModified).toBe(true)
-        })
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        expect(editor.getText()).toBe('something')
+        expect(suggestion.replacementPrefix).toBe('somet')
+        expect(suggestion.isPrefixModified).toBe(true)
       })
     })
 
     describe("when autocomplete-plus.suggestionListFollows is 'Cursor'", () => {
-      beforeEach(() => atom.config.set('autocomplete-plus.suggestionListFollows', 'Cursor'))
+      beforeEach(() => {
+        atom.config.set('autocomplete-plus.suggestionListFollows', 'Cursor')
+      })
 
-      it('places the suggestion list at the cursor', () => {
+      it('places the suggestion list at the cursor', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let overlayElement = editorView.querySelector('.autocomplete-plus')
-          expect(overlayElement).toExist()
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 10]))
+        let overlayElement = editorView.querySelector('.autocomplete-plus')
+        expect(overlayElement).toExist()
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 10]))
 
-          let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          expect(suggestionList.style['margin-left']).toBeFalsy()
-        })
+        let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        expect(suggestionList.style['margin-left']).toBeFalsy()
       })
 
-      it('closes the suggestion list if the user keeps typing', () => {
+      it('closes the suggestion list if the user keeps typing', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -1245,19 +1158,15 @@ describe('Autocomplete Manager', () => {
         // Trigger an autocompletion
         editor.moveToBottom()
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        editor.insertText('b')
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('keeps the suggestion list visible if the user keeps typing', () => {
+      it('keeps the suggestion list visible if the user keeps typing', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -1265,138 +1174,117 @@ describe('Autocomplete Manager', () => {
         // Trigger an autocompletion
         editor.moveToBottom()
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-
-          editor.insertText('c')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        editor.insertText('c')
+        await waitForAutocomplete(editor)
       })
     })
 
     describe("when autocomplete-plus.suggestionListFollows is 'Word'", () => {
-      beforeEach(() => atom.config.set('autocomplete-plus.suggestionListFollows', 'Word'))
-
-      it('opens to the correct position, and correctly closes on cancel', () => {
-        editor.insertText('xxxxxxxxxxx ab')
-        triggerAutocompletion(editor, false, 'c')
-
-        runs(() => {
-          let overlayElement = editorView.querySelector('.autocomplete-plus')
-          expect(overlayElement).toExist()
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
-        })
+      beforeEach(() => {
+        atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
       })
 
-      it('displays the suggestion list taking into account the passed back replacementPrefix', () => {
+      it('opens to the correct position, and correctly closes on cancel', async () => {
+        editor.insertText('xxxxxxxxxxx ab')
+        triggerAutocompletion(editor, false, 'c')
+        await waitForAutocomplete(editor)
+
+        let overlayElement = editorView.querySelector('.autocomplete-plus')
+        expect(overlayElement).toExist()
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
+      })
+
+      it('displays the suggestion list taking into account the passed back replacementPrefix', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}])
 
         editor.insertText('xxxxxxxxxxx ab:')
         triggerAutocompletion(editor, false, ':')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let overlayElement = editorView.querySelector('.autocomplete-plus')
-          expect(overlayElement).toExist()
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
-        })
+        let overlayElement = editorView.querySelector('.autocomplete-plus')
+        expect(overlayElement).toExist()
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
       })
 
-      it('displays the suggestion list with a negative margin to align the prefix with the word-container', () => {
+      it('displays the suggestion list with a negative margin to align the prefix with the word-container', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          let wordContainer = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .word-container')
-          let marginLeft = parseInt(suggestionList.style['margin-left'])
-          expect(Math.abs(wordContainer.offsetLeft + marginLeft)).toBeLessThan(2)
-        })
+        let suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        let wordContainer = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .word-container')
+        let marginLeft = parseInt(suggestionList.style['margin-left'])
+        expect(Math.abs(wordContainer.offsetLeft + marginLeft)).toBeLessThan(2)
       })
 
-      it('keeps the suggestion list planted at the beginning of the prefix when typing', () => {
+      it('keeps the suggestion list planted at the beginning of the prefix when typing', async () => {
         let overlayElement = null
         // Lots of x's to keep the margin offset away from the left of the window
         // See https://github.com/atom/autocomplete-plus/issues/399
         editor.insertText('xxxxxxxxxx xx')
         editor.insertText(' ')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          overlayElement = editorView.querySelector('.autocomplete-plus')
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
-          editor.insertText('a')
-          waitForAutocomplete()
-        })
+        overlayElement = editorView.querySelector('.autocomplete-plus')
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
+        editor.insertText('a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
 
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
+        editor.insertText('b')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
 
-          editor.backspace()
-          editor.backspace()
-          waitForAutocomplete()
-        })
+        editor.backspace()
+        editor.backspace()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
 
-          editor.backspace()
-          waitForAutocomplete()
-        })
+        editor.backspace()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
 
-          editor.insertText(' ')
-          editor.insertText('a')
-          editor.insertText('b')
-          editor.insertText('c')
-          waitForAutocomplete()
-        })
+        editor.insertText(' ')
+        editor.insertText('a')
+        editor.insertText('b')
+        editor.insertText('c')
+        await waitForAutocomplete(editor)
 
-        runs(() => expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14])))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 14]))
       })
 
-      it('when broken by a non-word character, the suggestion list is positioned at the beginning of the new word', () => {
+      it('when broken by a non-word character, the suggestion list is positioned at the beginning of the new word', async () => {
         let overlayElement = null
         editor.insertText('xxxxxxxxxxx')
         editor.insertText(' abc')
         editor.insertText('d')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          overlayElement = editorView.querySelector('.autocomplete-plus')
+        overlayElement = editorView.querySelector('.autocomplete-plus')
 
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
 
-          editor.insertText(' ')
-          editor.insertText('a')
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
+        editor.insertText(' ')
+        editor.insertText('a')
+        editor.insertText('b')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 17]))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 17]))
 
-          editor.backspace()
-          editor.backspace()
-          editor.backspace()
-          waitForAutocomplete()
-        })
+        editor.backspace()
+        editor.backspace()
+        editor.backspace()
+        await waitForAutocomplete(editor)
 
-        runs(() => expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12])))
+        expect(overlayElement.style.left).toBe(pixelLeftForBufferPosition([0, 12]))
       })
     })
 
@@ -1406,143 +1294,135 @@ describe('Autocomplete Manager', () => {
         editor.setCursorBufferPosition([0, 20])
       })
 
-      it('hides the suggestions list when a suggestion is confirmed', () => {
+      it('hides the suggestions list when a suggestion is confirmed', async () => {
         triggerAutocompletion(editor, false, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          // Accept suggestion
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+        // Accept suggestion
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
 
       describe('when the replacementPrefix is empty', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'someMethod()', replacementPrefix: ''}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'someMethod()', replacementPrefix: ''}])
+        })
 
-        it('will insert the text without replacing anything', () => {
+        it('will insert the text without replacing anything', async () => {
           editor.insertText('a')
           triggerAutocompletion(editor, false, '.')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-            expect(editor.getText()).toBe('ok then a.someMethod()')
-          })
+          expect(editor.getText()).toBe('ok then a.someMethod()')
         })
       })
 
       describe('when the alternate keyboard integration is used', () => {
         beforeEach(() => atom.config.set('autocomplete-plus.confirmCompletion', 'tab always, enter when suggestion explicitly selected'))
 
-        it('inserts the word on tab and moves the cursor to the end of the word', () => {
+        it('inserts the word on tab and moves the cursor to the end of the word', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('tab', {target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
+          let key = atom.keymaps.constructor.buildKeydownEvent('tab', {target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
 
-            expect(editor.getText()).toBe('ok then ab')
+          expect(editor.getText()).toBe('ok then ab')
 
-            let bufferPosition = editor.getCursorBufferPosition()
-            expect(bufferPosition.row).toEqual(0)
-            expect(bufferPosition.column).toEqual(10)
-          })
+          let bufferPosition = editor.getCursorBufferPosition()
+          expect(bufferPosition.row).toEqual(0)
+          expect(bufferPosition.column).toEqual(10)
         })
 
-        it('does not insert the word on enter', () => {
+        it('does not insert the word on enter', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
-            expect(editor.getText()).toBe('ok then a\n')
-          })
+          let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
+          expect(editor.getText()).toBe('ok then a\n')
         })
 
-        it('inserts the word on enter after the selection has been changed and moves the cursor to the end of the word', () => {
+        it('inserts the word on enter after the selection has been changed and moves the cursor to the end of the word', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            editorView = atom.views.getView(editor)
-            atom.commands.dispatch(editorView, 'core:move-down')
-            let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
+          editorView = atom.views.getView(editor)
+          atom.commands.dispatch(editorView, 'core:move-down')
+          let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
 
-            expect(editor.getText()).toBe('ok then abc')
+          expect(editor.getText()).toBe('ok then abc')
 
-            let bufferPosition = editor.getCursorBufferPosition()
-            expect(bufferPosition.row).toEqual(0)
-            expect(bufferPosition.column).toEqual(11)
-          })
+          let bufferPosition = editor.getCursorBufferPosition()
+          expect(bufferPosition.row).toEqual(0)
+          expect(bufferPosition.column).toEqual(11)
         })
       })
 
       describe('when tab is used to accept suggestions', () => {
         beforeEach(() => atom.config.set('autocomplete-plus.confirmCompletion', 'tab'))
 
-        it('inserts the word and moves the cursor to the end of the word', () => {
+        it('inserts the word and moves the cursor to the end of the word', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('tab', {target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
+          let key = atom.keymaps.constructor.buildKeydownEvent('tab', {target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
 
-            expect(editor.getText()).toBe('ok then ab')
+          expect(editor.getText()).toBe('ok then ab')
 
-            let bufferPosition = editor.getCursorBufferPosition()
-            expect(bufferPosition.row).toEqual(0)
-            expect(bufferPosition.column).toEqual(10)
-          })
+          let bufferPosition = editor.getCursorBufferPosition()
+          expect(bufferPosition.row).toEqual(0)
+          expect(bufferPosition.column).toEqual(10)
         })
 
-        it('does not insert the word when enter completion not enabled', () => {
+        it('does not insert the word when enter completion not enabled', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
-            expect(editor.getText()).toBe('ok then a\n')
-          })
+          let key = atom.keymaps.constructor.buildKeydownEvent('enter', {keyCode: 13, target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
+          expect(editor.getText()).toBe('ok then a\n')
         })
       })
 
       describe('when enter is used to accept suggestions', () => {
         beforeEach(() => atom.config.set('autocomplete-plus.confirmCompletion', 'enter'))
 
-        it('inserts the word and moves the cursor to the end of the word', () => {
+        it('inserts the word and moves the cursor to the end of the word', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('enter', {target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
+          let key = atom.keymaps.constructor.buildKeydownEvent('enter', {target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
 
-            expect(editor.getText()).toBe('ok then ab')
+          expect(editor.getText()).toBe('ok then ab')
 
-            let bufferPosition = editor.getCursorBufferPosition()
-            expect(bufferPosition.row).toEqual(0)
-            expect(bufferPosition.column).toEqual(10)
-          })
+          let bufferPosition = editor.getCursorBufferPosition()
+          expect(bufferPosition.row).toEqual(0)
+          expect(bufferPosition.column).toEqual(10)
         })
 
-        it('does not insert the word when tab completion not enabled', () => {
+        it('does not insert the word when tab completion not enabled', async () => {
           triggerAutocompletion(editor, false, 'a')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let key = atom.keymaps.constructor.buildKeydownEvent('tab', {keyCode: 13, target: document.activeElement})
-            atom.keymaps.handleKeyboardEvent(key)
-            expect(editor.getText()).toBe('ok then a ')
-          })
+          let key = atom.keymaps.constructor.buildKeydownEvent('tab', {keyCode: 13, target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
+          expect(editor.getText()).toBe('ok then a ')
         })
       })
 
       describe('when a suffix of the replacement matches the text after the cursor', () => {
-        it('overwrites that existing text with the replacement', () => {
+        it('overwrites that existing text with the replacement', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
@@ -1550,16 +1430,15 @@ describe('Autocomplete Manager', () => {
           editor.setText('ontwothree')
           editor.setCursorBufferPosition([0, 2])
           triggerAutocompletion(editor, false, 'e')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-            expect(editor.getText()).toBe('oneomgtwothree')
-          })
+          expect(editor.getText()).toBe('oneomgtwothree')
         })
 
-        it('does not overwrite any text if the "consumeSuffix" setting is disabled', () => {
+        it('does not overwrite any text if the "consumeSuffix" setting is disabled', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
@@ -1569,16 +1448,15 @@ describe('Autocomplete Manager', () => {
           editor.setText('ontwothree')
           editor.setCursorBufferPosition([0, 2])
           triggerAutocompletion(editor, false, 'e')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-            expect(editor.getText()).toBe('oneomgtwotwothree')
-          })
+          expect(editor.getText()).toBe('oneomgtwotwothree')
         })
 
-        it('does not overwrite non-word characters', () => {
+        it('does not overwrite non-word characters', async () => {
           spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo()', replacementPrefix: 'one'}
           ])
@@ -1586,13 +1464,12 @@ describe('Autocomplete Manager', () => {
           editor.setText('(on)three')
           editor.setCursorBufferPosition([0, 3])
           triggerAutocompletion(editor, false, 'e')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-            expect(editor.getText()).toBe('(oneomgtwo())three')
-          })
+          expect(editor.getText()).toBe('(oneomgtwo())three')
         })
       })
 
@@ -1600,131 +1477,110 @@ describe('Autocomplete Manager', () => {
         beforeEach(() =>
           spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'oneomgTwo', replacementPrefix: 'one'}]))
 
-        it('replaces the suffix with the replacement', () => {
+        it('replaces the suffix with the replacement', async () => {
           editor.setText('ontwothree')
           editor.setCursorBufferPosition([0, 2])
           triggerAutocompletion(editor, false, 'e')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
-            expect(editor.getText()).toBe('oneomgTwotwothree')
-          })
+          expect(editor.getText()).toBe('oneomgTwotwothree')
         })
       })
     })
 
     describe('when auto-activation is disabled', () => {
-      let [options] = []
-
-      beforeEach(() => atom.config.set('autocomplete-plus.enableAutoActivation', false))
-
-      it('does not show suggestions after a delay', () => {
-        triggerAutocompletion(editor)
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+      beforeEach(() => {
+        atom.config.set('autocomplete-plus.enableAutoActivation', false)
       })
 
-      it('shows suggestions when explicitly triggered', () => {
+      it('does not show suggestions after a delay', async () => {
         triggerAutocompletion(editor)
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        await timeoutPromise(100)
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
 
-      it('stays open when typing', () => {
+      it('shows suggestions when explicitly triggered', async () => {
+        triggerAutocompletion(editor)
+        await timeoutPromise(100)
+
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        await waitForAutocomplete(editor)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      })
+
+      it('stays open when typing', async () => {
         triggerAutocompletion(editor, false, 'a')
+        await timeoutPromise(100)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-          waitForAutocomplete()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        editor.insertText('b')
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
       })
 
-      it('accepts the suggestion if there is one', () => {
+      it('accepts the suggestion if there is one', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
+        await timeoutPromise(100)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-          waitForAutocomplete()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        await timeoutPromise(100)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          expect(editor.getText()).toBe('omgok')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        expect(editor.getText()).toBe('omgok')
       })
 
-      it('does not accept the suggestion if the event detail is activatedManually: false', () => {
+      it('does not accept the suggestion if the event detail is activatedManually: false', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
+        await timeoutPromise(100)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate', {activatedManually: false})
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate', {activatedManually: false})
+        await waitForAutocomplete(editor)
       })
 
-      it('does not accept the suggestion if auto-confirm single suggestion is disabled', () => {
+      it('does not accept the suggestion if auto-confirm single suggestion is disabled', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
+        await timeoutPromise(100)
 
-        runs(() => {
-          atom.config.set('autocomplete-plus.enableAutoConfirmSingleSuggestion', false)
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).toExist())
+        atom.config.set('autocomplete-plus.enableAutoConfirmSingleSuggestion', false)
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        await waitForAutocomplete(editor)
       })
 
-      it('includes the correct value for activatedManually when explicitly triggered', () => {
-        spyOn(provider, 'getSuggestions').andCallFake((o) => {
-          options = o
+      it('includes the correct value for activatedManually when explicitly triggered', async () => {
+        let receivedOptions
+        spyOn(provider, 'getSuggestions').andCallFake((options) => {
+          receivedOptions = options
           return [{text: 'omgok'}, {text: 'ahgok'}]
         })
 
         triggerAutocompletion(editor)
+        await timeoutPromise(100)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-          waitForAutocomplete()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(options).toBeDefined()
-          expect(options.activatedManually).toBe(true)
-        })
+        expect(receivedOptions).toBeDefined()
+        expect(receivedOptions.activatedManually).toBe(true)
       })
 
-      it('does not auto-accept a single suggestion when filtering', () => {
+      it('does not auto-accept a single suggestion when filtering', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
           let list = []
           if ('a'.indexOf(prefix) === 0) { list.push('a') }
@@ -1734,29 +1590,22 @@ describe('Autocomplete Manager', () => {
 
         editor.insertText('a')
         atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
+        expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(2)
 
-          editor.insertText('b')
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength(1)
-        })
+        editor.insertText('b')
+        await waitForAutocomplete(editor)
       })
     })
 
     describe('when the replacementPrefix doesnt match the actual prefix', () => {
       describe('when snippets are not used', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something', replacementPrefix: 'bcm'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something', replacementPrefix: 'bcm'}])
+        })
 
-        it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', () => {
+        it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', async () => {
           editor.setText(`abc abc
 def`
           )
@@ -1764,25 +1613,24 @@ def`
           editor.addCursorAtBufferPosition([0, 7])
           editor.addCursorAtBufferPosition([1, 3])
           triggerAutocompletion(editor, false, 'm')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            expect(editorView.querySelector('.autocomplete-plus')).toExist()
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-            expect(editor.getText()).toBe(`asomething asomething
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          expect(editor.getText()).toBe(`asomething asomething
 defm`
-            )
-          })
+          )
         })
       })
 
       describe('when snippets are used', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ok(${1:omg})', replacementPrefix: 'bcm'}])
-          waitsForPromise(() => atom.packages.activatePackage('snippets'))
+          await atom.packages.activatePackage('snippets')
         })
 
-        it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', () => {
+        it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', async () => {
           editor.setText(`abc abc
 def`
           )
@@ -1790,76 +1638,69 @@ def`
           editor.addCursorAtBufferPosition([0, 7])
           editor.addCursorAtBufferPosition([1, 3])
           triggerAutocompletion(editor, false, 'm')
+          await waitForAutocomplete(editor)
 
-          runs(() => {
-            expect(editorView.querySelector('.autocomplete-plus')).toExist()
-            let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-            atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
-            expect(editor.getText()).toBe(`aok(omg) aok(omg)
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
+          expect(editor.getText()).toBe(`aok(omg) aok(omg)
 defm`
-            )
-          })
+          )
         })
       })
     })
 
     describe('select-previous event', () => {
-      it('selects the previous item in the list', () => {
+      it('selects the previous item in the list', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
+        await waitForAutocomplete(editor)
+        let items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0]).toHaveClass('selected')
+        expect(items[1]).not.toHaveClass('selected')
+        expect(items[2]).not.toHaveClass('selected')
 
-        runs(() => {
-          let items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0]).toHaveClass('selected')
-          expect(items[1]).not.toHaveClass('selected')
-          expect(items[2]).not.toHaveClass('selected')
+        // Select previous item
+        atom.commands.dispatch(editorView, 'core:move-up')
 
-          // Select previous item
-          atom.commands.dispatch(editorView, 'core:move-up')
-
-          items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0]).not.toHaveClass('selected')
-          expect(items[1]).not.toHaveClass('selected')
-          expect(items[2]).toHaveClass('selected')
-        })
+        items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0]).not.toHaveClass('selected')
+        expect(items[1]).not.toHaveClass('selected')
+        expect(items[2]).toHaveClass('selected')
       })
 
-      it('closes the autocomplete when up arrow pressed when only one item displayed', () => {
+      it('closes the autocomplete when up arrow pressed when only one item displayed', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
 
         editor.insertText('q')
         editor.insertText('u')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          // two items displayed, should not close
-          atom.commands.dispatch(editorView, 'core:move-up')
-          advanceClock(1)
+        // two items displayed, should not close
+        atom.commands.dispatch(editorView, 'core:move-up')
+        await timeoutPromise(1)
 
-          let autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).toExist()
+        let autocomplete = editorView.querySelector('.autocomplete-plus')
+        expect(autocomplete).toExist()
 
-          editor.insertText('a')
-          waitForAutocomplete()
-        })
+        editor.insertText('a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).toExist()
+        autocomplete = editorView.querySelector('.autocomplete-plus')
+        expect(autocomplete).toExist()
 
-          // one item displayed, should close
-          atom.commands.dispatch(editorView, 'core:move-up')
-          advanceClock(1)
+        // one item displayed, should close
+        atom.commands.dispatch(editorView, 'core:move-up')
+        await timeoutPromise(1)
 
-          autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).not.toExist()
-        })
+        autocomplete = editorView.querySelector('.autocomplete-plus')
+        expect(autocomplete).not.toExist()
       })
 
-      it('does not close the autocomplete when up arrow pressed with multiple items displayed but triggered on one item', () => {
+      it('does not close the autocomplete when up arrow pressed with multiple items displayed but triggered on one item', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
@@ -1867,546 +1708,493 @@ defm`
         editor.insertText('q')
         editor.insertText('u')
         editor.insertText('a')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          editor.backspace()
-          waitForAutocomplete()
-        })
+        editor.backspace()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).toExist()
+        let autocomplete = editorView.querySelector('.autocomplete-plus')
+        expect(autocomplete).toExist()
 
-          atom.commands.dispatch(editorView, 'core:move-up')
-          advanceClock(1)
+        atom.commands.dispatch(editorView, 'core:move-up')
+        advanceClock(1)
 
-          autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).toExist()
-        })
+        autocomplete = editorView.querySelector('.autocomplete-plus')
+        expect(autocomplete).toExist()
       })
     })
 
     describe('select-next event', () => {
-      it('selects the next item in the list', () => {
-        triggerAutocompletion(editor, false, 'a')
-
-        runs(() => {
-          let items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0]).toHaveClass('selected')
-          expect(items[1]).not.toHaveClass('selected')
-          expect(items[2]).not.toHaveClass('selected')
-
-          // Select next item
-          atom.commands.dispatch(editorView, 'core:move-down')
-
-          items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0]).not.toHaveClass('selected')
-          expect(items[1]).toHaveClass('selected')
-          expect(items[2]).not.toHaveClass('selected')
-        })
+      beforeEach(() => {
       })
 
-      it('wraps to the first item when triggered at the end of the list', () => {
+      it('selects the next item in the list', async () => {
+        triggerAutocompletion(editor, false, 'a')
+        await waitForAutocomplete(editor)
+
+        let items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0]).toHaveClass('selected')
+        expect(items[1]).not.toHaveClass('selected')
+        expect(items[2]).not.toHaveClass('selected')
+
+        // Select next item
+        atom.commands.dispatch(editorView, 'core:move-down')
+
+        items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0]).not.toHaveClass('selected')
+        expect(items[1]).toHaveClass('selected')
+        expect(items[2]).not.toHaveClass('selected')
+      })
+
+      it('wraps to the first item when triggered at the end of the list', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let items = editorView.querySelectorAll('.autocomplete-plus li')
-          expect(items[0]).toHaveClass('selected')
-          expect(items[1]).not.toHaveClass('selected')
-          expect(items[2]).not.toHaveClass('selected')
+        let items = editorView.querySelectorAll('.autocomplete-plus li')
+        expect(items[0]).toHaveClass('selected')
+        expect(items[1]).not.toHaveClass('selected')
+        expect(items[2]).not.toHaveClass('selected')
 
-          let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          items = editorView.querySelectorAll('.autocomplete-plus li')
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        items = editorView.querySelectorAll('.autocomplete-plus li')
 
-          atom.commands.dispatch(suggestionListView, 'core:move-down')
-          expect(items[1]).toHaveClass('selected')
+        atom.commands.dispatch(suggestionListView, 'core:move-down')
+        expect(items[1]).toHaveClass('selected')
 
-          atom.commands.dispatch(suggestionListView, 'core:move-down')
-          expect(items[2]).toHaveClass('selected')
+        atom.commands.dispatch(suggestionListView, 'core:move-down')
+        expect(items[2]).toHaveClass('selected')
 
-          atom.commands.dispatch(suggestionListView, 'core:move-down')
-          expect(items[0]).toHaveClass('selected')
-        })
+        atom.commands.dispatch(suggestionListView, 'core:move-down')
+        expect(items[0]).toHaveClass('selected')
       })
     })
 
     describe('label rendering', () => {
       describe('when no labels are specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok'}])
+        })
 
-        it('displays the text in the suggestion', () => {
+        it('displays the text in the suggestion', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
-            let leftLabel = editorView.querySelector('.autocomplete-plus li .right-label')
-            let rightLabel = editorView.querySelector('.autocomplete-plus li .right-label')
+          await waitForAutocomplete(editor)
+          let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
+          let leftLabel = editorView.querySelector('.autocomplete-plus li .right-label')
+          let rightLabel = editorView.querySelector('.autocomplete-plus li .right-label')
 
-            expect(iconContainer.childNodes).toHaveLength(0)
-            expect(leftLabel.childNodes).toHaveLength(0)
-            expect(rightLabel.childNodes).toHaveLength(0)
-          })
+          expect(iconContainer.childNodes).toHaveLength(0)
+          expect(leftLabel.childNodes).toHaveLength(0)
+          expect(rightLabel.childNodes).toHaveLength(0)
         })
       })
 
       describe('when `type` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'omg'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'omg'}])
+        })
 
-        it('displays an icon in the icon-container', () => {
+        it('displays an icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon')
-            expect(icon.textContent).toBe('o')
-          })
+          await waitForAutocomplete(editor)
+
+          let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon')
+          expect(icon.textContent).toBe('o')
         })
       })
 
       describe('when the `type` specified has a default icon', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'snippet'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'snippet'}])
+        })
 
-        it('displays the default icon in the icon-container', () => {
+        it('displays the default icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon i')
-            expect(icon).toHaveClass('icon-move-right')
-          })
+          await waitForAutocomplete(editor)
+
+          let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon i')
+          expect(icon).toHaveClass('icon-move-right')
         })
       })
 
       describe('when `type` is an empty string', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: ''}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: ''}])
+        })
 
-        it('does not display an icon in the icon-container', () => {
+        it('does not display an icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
-            expect(iconContainer.childNodes).toHaveLength(0)
-          })
+          await waitForAutocomplete(editor)
+
+          let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
+          expect(iconContainer.childNodes).toHaveLength(0)
         })
       })
 
       describe('when `iconHTML` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}])
+        })
 
-        it('displays an icon in the icon-container', () => {
+        it('displays an icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon .omg')
-            expect(icon).toExist()
-          })
+          await waitForAutocomplete(editor)
+
+          let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon .omg')
+          expect(icon).toExist()
         })
       })
 
       describe('when `iconHTML` is false', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: false}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: false}])
+        })
 
-        it('does not display an icon in the icon-container', () => {
+        it('does not display an icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
-            expect(iconContainer.childNodes).toHaveLength(0)
-          })
+          await waitForAutocomplete(editor)
+
+          let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
+          expect(iconContainer.childNodes).toHaveLength(0)
         })
       })
 
       describe('when `iconHTML` is not a string and a `type` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: true}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: true}])
+        })
 
-        it('displays the default icon in the icon-container', () => {
+        it('displays the default icon in the icon-container', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon')
-            expect(icon.textContent).toBe('s')
-          })
+          await waitForAutocomplete(editor)
+
+          let icon = editorView.querySelector('.autocomplete-plus li .icon-container .icon')
+          expect(icon.textContent).toBe('s')
         })
       })
 
       describe('when `iconHTML` is not a string and no type is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: true}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: true}])
+        })
 
-        it('it does not display an icon', () => {
+        it('it does not display an icon', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
-            expect(iconContainer.childNodes).toHaveLength(0)
-          })
+          await waitForAutocomplete(editor)
+
+          let iconContainer = editorView.querySelector('.autocomplete-plus li .icon-container')
+          expect(iconContainer.childNodes).toHaveLength(0)
         })
       })
 
       describe('when `rightLabel` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}])
+        })
 
-        it('displays the text in the suggestion', () => {
+        it('displays the text in the suggestion', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let label = editorView.querySelector('.autocomplete-plus li .right-label')
-            expect(label).toHaveText('<i class="something">sometext</i>')
-          })
+          await waitForAutocomplete(editor)
+
+          let label = editorView.querySelector('.autocomplete-plus li .right-label')
+          expect(label).toHaveText('<i class="something">sometext</i>')
         })
       })
 
       describe('when `rightLabelHTML` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}])
+        })
 
-        it('displays the text in the suggestion', () => {
+        it('displays the text in the suggestion', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let label = editorView.querySelector('.autocomplete-plus li .right-label .something')
-            expect(label).toHaveText('sometext')
-          })
+          await waitForAutocomplete(editor)
+
+          let label = editorView.querySelector('.autocomplete-plus li .right-label .something')
+          expect(label).toHaveText('sometext')
         })
       })
 
       describe('when `leftLabel` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}])
+        })
 
-        it('displays the text in the suggestion', () => {
+        it('displays the text in the suggestion', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let label = editorView.querySelector('.autocomplete-plus li .left-label')
-            expect(label).toHaveText('<i class="something">sometext</i>')
-          })
+          await waitForAutocomplete(editor)
+
+          let label = editorView.querySelector('.autocomplete-plus li .left-label')
+          expect(label).toHaveText('<i class="something">sometext</i>')
         })
       })
 
       describe('when `leftLabelHTML` is specified', () => {
-        beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}]))
+        beforeEach(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}])
+        })
 
-        it('displays the text in the suggestion', () => {
+        it('displays the text in the suggestion', async () => {
           triggerAutocompletion(editor)
-          runs(() => {
-            let label = editorView.querySelector('.autocomplete-plus li .left-label .something')
-            expect(label).toHaveText('sometext')
-          })
+          await waitForAutocomplete(editor)
+
+          let label = editorView.querySelector('.autocomplete-plus li .left-label .something')
+          expect(label).toHaveText('sometext')
         })
       })
     })
 
     describe('when clicking in the suggestion list', () => {
-      beforeEach(() =>
+      beforeEach(() => {
         spyOn(provider, 'getSuggestions').andCallFake(() => {
           let list = ['ab', 'abc', 'abcd', 'abcde']
           return (list.map((text) => ({text, description: `${text} yeah ok`})))
         })
-      )
-
-      it('will select the item and confirm the selection', () => {
-        triggerAutocompletion(editor, true, 'a')
-
-        runs(() => {
-          // Get the second item
-          let item = editorView.querySelectorAll('.autocomplete-plus li')[1]
-
-          // Click the item, expect list to be hidden and text to be added
-          let mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mousedown', true, true, window)
-          item.dispatchEvent(mouse)
-          mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mouseup', true, true, window)
-          item.dispatchEvent(mouse)
-
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          expect(editor.getBuffer().getLastLine()).toEqual(item.textContent.trim())
-        })
       })
 
-      it('will not close the list when the description is clicked', () => {
+      it('will select the item and confirm the selection', async () => {
         triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          let description = editorView.querySelector('.autocomplete-plus .suggestion-description-content')
+        // Get the second item
+        let item = editorView.querySelectorAll('.autocomplete-plus li')[1]
 
-          // Click the description, expect list to still show
-          let mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mousedown', true, true, window)
-          description.dispatchEvent(mouse)
-          mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mouseup', true, true, window)
-          description.dispatchEvent(mouse)
+        // Click the item, expect list to be hidden and text to be added
+        let mouse = document.createEvent('MouseEvents')
+        mouse.initMouseEvent('mousedown', true, true, window)
+        item.dispatchEvent(mouse)
+        mouse = document.createEvent('MouseEvents')
+        mouse.initMouseEvent('mouseup', true, true, window)
+        item.dispatchEvent(mouse)
 
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        expect(editor.getBuffer().getLastLine()).toEqual(item.textContent.trim())
+      })
+
+      it('will not close the list when the description is clicked', async () => {
+        triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
+
+        let description = editorView.querySelector('.autocomplete-plus .suggestion-description-content')
+
+        // Click the description, expect list to still show
+        let mouse = document.createEvent('MouseEvents')
+        mouse.initMouseEvent('mousedown', true, true, window)
+        description.dispatchEvent(mouse)
+        mouse = document.createEvent('MouseEvents')
+        mouse.initMouseEvent('mouseup', true, true, window)
+        description.dispatchEvent(mouse)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
       })
     })
 
     describe('Keybind to navigate to descriptionMoreLink', () => {
-      it('triggers openExternal on keybind if there is a description', () => {
+      it('triggers openExternal on keybind if there is a description', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', description: 'it is ab'}])
         let shell = require('shell')
         spyOn(shell, 'openExternal')
 
         triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
-          expect(shell.openExternal).toHaveBeenCalled()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
+        expect(shell.openExternal).toHaveBeenCalled()
       })
-      it('does not trigger openExternal on keybind if there is not a description', () => {
+
+      it('does not trigger openExternal on keybind if there is not a description', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}])
         let shell = require('shell')
         spyOn(shell, 'openExternal')
 
         triggerAutocompletion(editor, true, 'a')
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
-          expect(shell.openExternal).not.toHaveBeenCalled()
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        atom.commands.dispatch(editorView, 'autocomplete-plus:navigate-to-description-more-link')
+        expect(shell.openExternal).not.toHaveBeenCalled()
       })
     })
   })
 
   describe('when opening a file without a path', () => {
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open('').then((e) => {
-          editor = e
-          editorView = atom.views.getView(editor)
-        })
-      )
+    beforeEach(async () => {
+      editor = await atom.workspace.open('')
+      editorView = atom.views.getView(editor)
 
-      waitsForPromise(() => atom.packages.activatePackage('language-text'))
+      await atom.packages.activatePackage('language-text')
 
       // Activate the package
-      waitsForPromise(() => atom.packages.activatePackage('autocomplete-plus').then((a) => {
-        mainModule = a.mainModule
-      }))
+      mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-      waitsFor(() => {
-        if (!mainModule || !mainModule.autocompleteManager) {
-          return false
-        }
-        return mainModule.autocompleteManager.ready
+      await conditionPromise(() => {
+        return mainModule && mainModule.autocompleteManager && mainModule.autocompleteManager.ready
       })
 
-      runs(() => {
-        ({ autocompleteManager } = mainModule)
-        spyOn(autocompleteManager, 'findSuggestions').andCallThrough()
-        spyOn(autocompleteManager, 'displaySuggestions').andCallThrough()
-      })
+      ;({ autocompleteManager } = mainModule)
+      spyOn(autocompleteManager, 'findSuggestions').andCallThrough()
+      spyOn(autocompleteManager, 'displaySuggestions').andCallThrough()
     })
 
     describe('when strict matching is used', () => {
       beforeEach(() => atom.config.set('autocomplete-plus.strictMatching', true))
 
-      it('using strict matching does not cause issues when typing', () => {
-        // FIXME: WTF does this test even test?
-        runs(() => {
-          editor.moveToBottom()
-          editor.insertText('h')
-          editor.insertText('e')
-          editor.insertText('l')
-          editor.insertText('l')
-          editor.insertText('o')
-          return advanceClock(completionDelay + 1000)
-        })
+      it('using strict matching does not cause issues when typing', async () => {
+        editor.moveToBottom()
+        editor.insertText('h')
+        editor.insertText('e')
+        editor.insertText('l')
+        editor.insertText('l')
+        editor.insertText('o')
 
-        waitsFor(() => autocompleteManager.findSuggestions.calls.length === 1)
+        await conditionPromise(
+          () => autocompleteManager.findSuggestions.calls.length === 1
+        )
       })
     })
   })
 
   describe('when opening a javascript file', () => {
-    beforeEach(() => {
-      runs(() => atom.config.set('autocomplete-plus.enableAutoActivation', true))
+    beforeEach(async () => {
+      atom.config.set('autocomplete-plus.enableAutoActivation', true)
 
-      waitsForPromise(() => atom.workspace.open('sample.js').then((e) => {
-        editor = e
-        editorView = atom.views.getView(editor)
-      }))
+      editor = await atom.workspace.open('sample.js')
+      editorView = atom.views.getView(editor)
 
-      waitsForPromise(() => atom.packages.activatePackage('language-javascript'))
+      await atom.packages.activatePackage('language-javascript')
 
-      // Activate the package
-      waitsForPromise(() => atom.packages.activatePackage('autocomplete-plus').then((a) => {
-        mainModule = a.mainModule
-      }))
+      mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-      waitsFor(() => {
+      await conditionPromise(() => {
         autocompleteManager = mainModule.autocompleteManager
         return autocompleteManager
       })
 
-      runs(() => advanceClock(autocompleteManager.providerManager.defaultProvider.deferBuildWordListInterval))
+      await timeoutPromise(autocompleteManager.providerManager.defaultProvider.deferBuildWordListInterval + 100)
     })
 
     describe('when the built-in provider is disabled', () =>
-      it('should not show the suggestion list', () => {
+      it('should not show the suggestion list', async () => {
         atom.config.set('autocomplete-plus.enableBuiltinProvider', false)
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         triggerAutocompletion(editor)
+        await timeoutPromise(100)
 
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
     )
 
     describe('when the buffer changes', () => {
-      it('should show the suggestion list when suggestions are found', () => {
+      it('should show the suggestion list when suggestions are found', async () => {
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         triggerAutocompletion(editor)
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          // Check suggestions
-          let suggestions = ['function', 'if', 'left', 'shift']
-          let s = editorView.querySelectorAll('.autocomplete-plus li span.word')
-          for (let i = 0; i < s.length; i++) {
-            let item = s[i]
-            expect(item.innerText).toEqual(suggestions[i])
-          }
-        })
+        // Check suggestions
+        let suggestions = ['function', 'if', 'left', 'shift']
+        let s = editorView.querySelectorAll('.autocomplete-plus li span.word')
+        for (let i = 0; i < s.length; i++) {
+          let item = s[i]
+          expect(item.innerText).toEqual(suggestions[i])
+        }
       })
 
-      it('should not show the suggestion list when no suggestions are found', () => {
+      it('should not show the suggestion list when no suggestions are found', async () => {
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
         editor.moveToBottom()
         editor.insertText('x')
 
-        waitForAutocomplete()
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        await waitForAutocompleteToDisappear(editor)
       })
 
-      it('shows the suggestion list on backspace if allowed', () => {
-        runs(() => {
-          atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', true)
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-          editor.moveToBottom()
-          editor.insertText('f')
-          editor.insertText('u')
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.insertText('\r')
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(editor.lineTextForBufferRow(13)).toBe('f')
-        })
-      })
-
-      it('does not shows the suggestion list on backspace if disallowed', () => {
-        runs(() => {
-          atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', false)
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-          editor.moveToBottom()
-          editor.insertText('f')
-          editor.insertText('u')
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.insertText('\r')
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
-
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          expect(editor.lineTextForBufferRow(13)).toBe('f')
-        })
-      })
-
-      it("keeps the suggestion list open when it's already open on backspace", () => {
+      it('shows the suggestion list on backspace if allowed', async () => {
+        atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', true)
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
         editor.moveToBottom()
         editor.insertText('f')
         editor.insertText('u')
+        await waitForAutocomplete(editor)
 
-        waitForAutocomplete()
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        editor.insertText('\r')
+        await waitForAutocompleteToDisappear(editor)
 
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
+        await timeoutPromise(100)
 
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
+        await waitForAutocomplete(editor)
 
-          waitForAutocomplete()
-        })
-
-        runs(() => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          expect(editor.lineTextForBufferRow(13)).toBe('f')
-        })
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editor.lineTextForBufferRow(13)).toBe('f')
       })
 
-      it("does not open the suggestion on backspace when it's closed", () => {
+      it('does not shows the suggestion list on backspace if disallowed', async () => {
+        atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', false)
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+        editor.moveToBottom()
+        editor.insertText('f')
+        editor.insertText('u')
+        await waitForAutocomplete(editor)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        editor.insertText('\r')
+
+        await waitForAutocompleteToDisappear(editor)
+        let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
+
+        await waitForAutocompleteToDisappear(editor)
+        key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
+        await timeoutPromise(100)
+
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        expect(editor.lineTextForBufferRow(13)).toBe('f')
+      })
+
+      it("keeps the suggestion list open when it's already open on backspace", async () => {
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+        editor.moveToBottom()
+        editor.insertText('f')
+        editor.insertText('u')
+        await waitForAutocomplete(editor)
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+        let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
+        await waitForAutocomplete(editor)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+        expect(editor.lineTextForBufferRow(13)).toBe('f')
+      })
+
+      it("does not open the suggestion on backspace when it's closed", async () => {
         atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', false)
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
         editor.setCursorBufferPosition([2, 39]) // at the end of `items`
 
-        runs(() => {
-          let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
+        let key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+        atom.keymaps.handleKeyboardEvent(key)
 
-          waitForAutocomplete()
-        })
-
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        await timeoutPromise(100)
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
 
-      it('does not update the suggestion list while composition is in progress', () => {
+      it('does not update the suggestion list while composition is in progress', async () => {
         const activeElement = editorView.querySelector('input')
         spyOn(autocompleteManager.suggestionList, 'changeItems').andCallThrough()
 
@@ -2414,54 +2202,46 @@ defm`
         editor.insertText('q')
         editor.insertText('u')
 
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
-          expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
-          autocompleteManager.suggestionList.changeItems.reset()
+        expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
+        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.reset()
 
-          activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {data: 'i', target: activeElement}))
-          triggerAutocompletion(editor, false, 'i')
-        })
+        activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {data: 'i', target: activeElement}))
+        triggerAutocompletion(editor, false, 'i')
 
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() => {
-          expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
-          expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
-          autocompleteManager.suggestionList.changeItems.reset()
+        expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
+        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.reset()
 
-          activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: 'ï', target: activeElement}))
-          editor.selectLeft()
+        activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: 'ï', target: activeElement}))
+        editor.selectLeft()
 
-          editor.insertText('ï')
-          advanceClock(100)
-        })
+        editor.insertText('ï')
 
-        waits(100)
+        const initialCallCount = autocompleteManager.suggestionList.changeItems.callCount
+        await conditionPromise(() => autocompleteManager.suggestionList.changeItems.callCount > initialCallCount)
 
-        runs(() => {
-          expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalledWith(null)
-          activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: activeElement}))
-        })
+        expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalledWith(null)
+        activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: activeElement}))
       })
 
-      it('does not show the suggestion list when it is triggered then no longer needed', () => {
-        runs(() => {
-          editor.moveToBottom()
-          editor.insertText('f')
-          editor.insertText('u')
-          editor.insertText('\r')
+      it('does not show the suggestion list when it is triggered then no longer needed', async () => {
+        editor.moveToBottom()
+        editor.insertText('f')
+        editor.insertText('u')
+        editor.insertText('\r')
 
-          waitForAutocomplete()
-        })
+        await timeoutPromise(100)
 
-        runs(() => expect(editorView.querySelector('.autocomplete-plus')).not.toExist())
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       })
     })
 
-    describe('.cancel()', () =>
+    describe('.cancel()', () => {
       it('unbinds autocomplete event handlers for move-up and move-down', () => {
         triggerAutocompletion(editor, false)
 
@@ -2473,45 +2253,40 @@ defm`
         atom.commands.dispatch(editorView, 'core:move-up')
         expect(editor.getCursorBufferPosition().row).toBe(0)
       })
-    )
+    })
   })
 
   describe('when a long completion exists', () => {
-    beforeEach(() => {
-      runs(() => atom.config.set('autocomplete-plus.enableAutoActivation', true))
+    beforeEach(async () => {
+      atom.config.set('autocomplete-plus.enableAutoActivation', true)
 
-      waitsForPromise(() => atom.workspace.open('samplelong.js').then((e) => { editor = e }))
+      editor = await atom.workspace.open('samplelong.js')
 
       // Activate the package
-      waitsForPromise(() => atom.packages.activatePackage('autocomplete-plus').then((a) => {
-        mainModule = a.mainModule
-      }))
+      mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-      return waitsFor(() => {
-        autocompleteManager = mainModule.autocompleteManager
-        return autocompleteManager
-      })
+      await conditionPromise(() => mainModule.autocompleteManager)
+      autocompleteManager = mainModule.autocompleteManager
     })
 
-    it('sets the width of the view to be wide enough to contain the longest completion without scrolling', () => {
+    it('sets the width of the view to be wide enough to contain the longest completion without scrolling', async () => {
       editor.moveToBottom()
       editor.insertNewline()
       editor.insertText('t')
 
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
-        expect(suggestionListView.scrollWidth).toBe(suggestionListView.offsetWidth)
-      })
+      let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
+      expect(suggestionListView.scrollWidth).toBe(suggestionListView.offsetWidth)
     })
   })
 
   describe('when watching an external text editor for a given set of provider labels', () => {
-    let [bottomEditor, bottomEditorView, autocompleteDisposable] = []
-    beforeEach(async () => {
-      jasmine.useRealClock()
+    let bottomEditor
+    let bottomEditorView
+    let autocompleteDisposable
 
+    beforeEach(async () => {
       // Activate package.
       const pck = await atom.packages.activatePackage('autocomplete-plus')
       mainModule = pck.mainModule
@@ -2550,9 +2325,7 @@ defm`
     it('provides appropriate autocompletions when each editor is focused.', async () => {
       bottomEditorView.focus()
       triggerAutocompletion(bottomEditor)
-      await conditionPromise(
-        () => bottomEditorView.querySelectorAll('.autocomplete-plus li').length === 1
-      )
+      await waitForAutocomplete(bottomEditor)
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -2562,9 +2335,7 @@ defm`
 
       editorView.focus()
       triggerAutocompletion(editor)
-      await conditionPromise(
-        () => editorView.querySelectorAll('.autocomplete-plus li').length === 1
-      )
+      await waitForAutocomplete(editor)
 
       expect(bottomEditorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -2573,14 +2344,12 @@ defm`
       expect(items[0].innerText.trim()).toEqual('center')
     })
 
-    it('stops providing autocompletions when disposed.', () => {
+    it('stops providing autocompletions when disposed.', async () => {
       autocompleteDisposable.dispose()
       bottomEditorView.focus()
       triggerAutocompletion(bottomEditor)
-
-      runs(() => {
-        expect(bottomEditorView.querySelector('.autocomplete-plus')).not.toExist()
-      })
+      await timeoutPromise(100)
+      expect(bottomEditorView.querySelector('.autocomplete-plus')).not.toExist()
     })
   })
 })

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -17,7 +17,7 @@ const path = require('path')
 let NodeTypeText = 3
 
 describe('Autocomplete Manager', () => {
-  let autocompleteManager, completionDelay, editor, editorView, gutterWidth, mainModule, workspaceElement
+  let autocompleteManager, editor, editorView, gutterWidth, mainModule, workspaceElement
 
   let pixelLeftForBufferPosition = (bufferPosition) => {
     let gutter = editorView.querySelector('.gutter')
@@ -41,9 +41,7 @@ describe('Autocomplete Manager', () => {
     atom.config.set('editor.fontSize', '16')
 
     // Set the completion delay
-    completionDelay = 100
-    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-    completionDelay += 100 // Rendering
+    atom.config.set('autocomplete-plus.autoActivationDelay', 100)
 
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -1717,7 +1715,6 @@ defm`
         expect(autocomplete).toExist()
 
         atom.commands.dispatch(editorView, 'core:move-up')
-        advanceClock(1)
 
         autocomplete = editorView.querySelector('.autocomplete-plus')
         expect(autocomplete).toExist()

--- a/spec/autocomplete-manager-undo-spec.js
+++ b/spec/autocomplete-manager-undo-spec.js
@@ -50,25 +50,25 @@ describe('Autocomplete Manager', () => {
       })
     })
 
-    it('restores the previous state', () => {
+    it('restores the previous state', async () => {
+      jasmine.useRealClock()
+
       // Trigger an autocompletion
       editor.moveToBottom()
       editor.moveToBeginningOfLine()
       editor.insertText('f')
 
-      waitForAutocomplete()
+      await waitForAutocomplete(editor)
 
-      runs(() => {
-        // Accept suggestion
-        editorView = atom.views.getView(editor)
-        atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+      // Accept suggestion
+      editorView = atom.views.getView(editor)
+      atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
 
-        expect(editor.getBuffer().getLastLine()).toEqual('function')
+      expect(editor.getBuffer().getLastLine()).toEqual('function')
 
-        editor.undo()
+      editor.undo()
 
-        expect(editor.getBuffer().getLastLine()).toEqual('f')
-      })
+      expect(editor.getBuffer().getLastLine()).toEqual('f')
     })
   })
 })

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -62,23 +62,21 @@ describe('Autocomplete', () => {
     )
   )
 
-  describe('@deactivate()', () =>
-    it('removes all autocomplete views', () =>
-      runs(() => {
-        // Trigger an autocompletion
-        editor.moveToBottom()
-        editor.insertText('A')
+  describe('@deactivate()', () => {
+    it('removes all autocomplete views', async () => {
+      jasmine.useRealClock()
 
-        waitForAutocomplete()
+      // Trigger an autocompletion
+      editor.moveToBottom()
+      editor.insertText('A')
 
-        runs(async () => {
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+      await waitForAutocomplete(editor)
 
-          // Deactivate the package
-          await atom.packages.deactivatePackage('autocomplete-plus')
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-        })
-      })
-    )
-  )
+      expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+      // Deactivate the package
+      await atom.packages.deactivatePackage('autocomplete-plus')
+      expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+    })
+  })
 })

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -5,7 +5,7 @@ import { triggerAutocompletion, waitForAutocomplete, conditionPromise } from './
 import grim from 'grim'
 
 describe('Provider API Legacy', () => {
-  let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider] = []
+  let [editor, mainModule, autocompleteManager, registration, testProvider] = []
 
   beforeEach(async () => {
     jasmine.useRealClock()
@@ -16,9 +16,7 @@ describe('Provider API Legacy', () => {
     atom.config.set('editor.fontSize', '16')
 
     // Set the completion delay
-    completionDelay = 100
-    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-    completionDelay += 100 // Rendering
+    atom.config.set('autocomplete-plus.autoActivationDelay', 100)
 
     let workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -1,7 +1,7 @@
 'use babel'
 /* eslint-env jasmine */
 
-import {waitForAutocomplete, waitForAutocompletePromise, triggerAutocompletion} from './spec-helper'
+import {waitForAutocomplete, triggerAutocompletion} from './spec-helper'
 
 describe('Provider API', () => {
   let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
@@ -103,7 +103,7 @@ describe('Provider API', () => {
 
         spyOn(testProvider, 'getSuggestions')
         triggerAutocompletion(editor, true, 'o')
-        await waitForAutocompletePromise(editor)
+        await waitForAutocomplete(editor)
 
         let args = testProvider.getSuggestions.mostRecentCall.args[0]
         expect(args.editor).toBeDefined()
@@ -132,7 +132,7 @@ describe('Provider API', () => {
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
         triggerAutocompletion(editor, true, 'o')
-        await waitForAutocompletePromise(editor)
+        await waitForAutocomplete(editor)
 
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.element.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
@@ -158,7 +158,7 @@ describe('Provider API', () => {
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
         triggerAutocompletion(editor, true, 'o')
-        await waitForAutocompletePromise(editor)
+        await waitForAutocomplete(editor)
 
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         expect(suggestionListView.element.querySelector('.word')).toHaveText('displayOHAI')
@@ -180,7 +180,7 @@ describe('Provider API', () => {
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
         triggerAutocompletion(editor, true, 'o')
-        await waitForAutocompletePromise(editor)
+        await waitForAutocomplete(editor)
 
         let suggestionListView = autocompleteManager.suggestionList.suggestionListElement
         let content = suggestionListView.element.querySelector('.suggestion-description-content')
@@ -206,7 +206,7 @@ describe('Provider API', () => {
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
         triggerAutocompletion(editor, true, 'o')
-        await waitForAutocompletePromise(editor)
+        await waitForAutocomplete(editor)
 
         expect(autocompleteManager.suggestionList.items[0].description).toBe('foo')
       })
@@ -217,7 +217,8 @@ describe('Provider API', () => {
 
       beforeEach(() => editor.setText(''))
 
-      it('filters suggestions based on the default prefix', () => {
+      it('filters suggestions based on the default prefix', async () => {
+        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,
@@ -235,17 +236,16 @@ describe('Provider API', () => {
 
         editor.insertText('o')
         editor.insertText('k')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() =>
-          expect(getSuggestions()).toEqual([
-            {text: 'ok'},
-            {text: 'okwow'}
-          ])
-        )
+        expect(getSuggestions()).toEqual([
+          {text: 'ok'},
+          {text: 'okwow'}
+        ])
       })
 
-      it('filters suggestions based on the specified replacementPrefix for each suggestion', () => {
+      it('filters suggestions based on the specified replacementPrefix for each suggestion', async () => {
+        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,
@@ -263,18 +263,17 @@ describe('Provider API', () => {
         registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
         editor.insertText('h')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() =>
-          expect(getSuggestions()).toEqual([
-            {text: '::cats'},
-            {text: 'hai'},
-            {text: 'something'}
-          ])
-        )
+        expect(getSuggestions()).toEqual([
+          {text: '::cats'},
+          {text: 'hai'},
+          {text: 'something'}
+        ])
       })
 
-      it('allows all suggestions when the prefix is an empty string / space', () => {
+      it('allows all suggestions when the prefix is an empty string / space', async () => {
+        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,
@@ -291,15 +290,13 @@ describe('Provider API', () => {
 
         editor.insertText('h')
         editor.insertText(' ')
-        waitForAutocomplete()
+        await waitForAutocomplete(editor)
 
-        runs(() =>
-          expect(getSuggestions()).toEqual([
-            {text: 'ohai'},
-            {text: 'hai'},
-            {text: 'okwow'}
-          ])
-        )
+        expect(getSuggestions()).toEqual([
+          {text: 'ohai'},
+          {text: 'hai'},
+          {text: 'okwow'}
+        ])
       })
     })
   })

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -4,7 +4,7 @@
 import {waitForAutocomplete, triggerAutocompletion, conditionPromise} from './spec-helper'
 
 describe('Provider API', () => {
-  let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
+  let [editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
 
   beforeEach(async () => {
     jasmine.useRealClock()
@@ -14,9 +14,7 @@ describe('Provider API', () => {
     atom.config.set('editor.fontSize', '16')
 
     // Set the completion delay
-    completionDelay = 100
-    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-    completionDelay += 100 // Rendering
+    atom.config.set('autocomplete-plus.autoActivationDelay', 100)
 
     let workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -1,35 +1,32 @@
 'use babel'
 /* eslint-env jasmine */
 
-import {waitForAutocomplete, triggerAutocompletion} from './spec-helper'
+import {waitForAutocomplete, triggerAutocompletion, conditionPromise} from './spec-helper'
 
 describe('Provider API', () => {
   let [completionDelay, editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
 
-  beforeEach(() => {
-    runs(() => {
-      // Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      atom.config.set('editor.fontSize', '16')
+  beforeEach(async () => {
+    jasmine.useRealClock()
 
-      // Set the completion delay
-      completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
-      completionDelay += 100 // Rendering
+    // Set to live completion
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    atom.config.set('editor.fontSize', '16')
 
-      let workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
-    })
+    // Set the completion delay
+    completionDelay = 100
+    atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
+    completionDelay += 100 // Rendering
+
+    let workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
     // Activate the package
-    waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('language-javascript'),
-        atom.workspace.open('sample.js').then((e) => { editor = e }),
-        atom.packages.activatePackage('autocomplete-plus').then((a) => { mainModule = a.mainModule })
-      ]))
+    await atom.packages.activatePackage('language-javascript')
+    editor = await atom.workspace.open('sample.js')
+    mainModule = (await atom.packages.activatePackage('autocomplete-plus')).mainModule
 
-    waitsFor(() => {
+    await conditionPromise(() => {
       autocompleteManager = mainModule.autocompleteManager
       return autocompleteManager
     })
@@ -48,10 +45,6 @@ describe('Provider API', () => {
 
   describe('Provider API v2.0.0', () => {
     describe('common functionality', () => {
-      beforeEach(() => {
-        jasmine.useRealClock()
-      })
-
       it('registers the provider specified by [provider]', () => {
         testProvider = {
           scopeSelector: '.source.js,.source.coffee',
@@ -218,7 +211,6 @@ describe('Provider API', () => {
       beforeEach(() => editor.setText(''))
 
       it('filters suggestions based on the default prefix', async () => {
-        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,
@@ -245,7 +237,6 @@ describe('Provider API', () => {
       })
 
       it('filters suggestions based on the specified replacementPrefix for each suggestion', async () => {
-        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,
@@ -273,7 +264,6 @@ describe('Provider API', () => {
       })
 
       it('allows all suggestions when the prefix is an empty string / space', async () => {
-        jasmine.useRealClock()
         testProvider = {
           scopeSelector: '.source.js',
           filterSuggestions: true,

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -1,7 +1,6 @@
 /* eslint-env jasmine */
 /* eslint-disable no-template-curly-in-string */
 const SuggestionListElement = require('../lib/suggestion-list-element')
-const {waitForAutocomplete} = require('./spec-helper')
 
 const fragmentToHtml = fragment => {
   const el = document.createElement('span')
@@ -66,7 +65,9 @@ describe('Suggestion List Element', () => {
   describe('itemChanged', () => {
     beforeEach(() => jasmine.attachToDOM(suggestionListElement.element))
 
-    it('updates the list item', () => {
+    it('updates the list item', async () => {
+      jasmine.useRealClock()
+
       const suggestion = {text: 'foo'}
       const newSuggestion = {text: 'foo', description: 'foobar', rightLabel: 'foo'}
       suggestionListElement.model = {items: [newSuggestion]}
@@ -76,15 +77,11 @@ describe('Suggestion List Element', () => {
 
       suggestionListElement.itemChanged({suggestion: newSuggestion, index: 0})
 
-      waitForAutocomplete()
+      expect(suggestionListElement.element.querySelector('.right-label').innerText)
+        .toBe('foo')
 
-      runs(() => {
-        expect(suggestionListElement.element.querySelector('.right-label').innerText)
-          .toBe('foo')
-
-        expect(suggestionListElement.element.querySelector('.suggestion-description-content').innerText)
-          .toBe('foobar')
-      })
+      expect(suggestionListElement.element.querySelector('.suggestion-description-content').innerText)
+        .toBe('foobar')
     })
   })
 


### PR DESCRIPTION
🍐'd with @rafeca

We're hoping that avoiding Jasmine's queue-based helpers and moving to async/await will help us avoid some flakiness in this package's tests that we've observed since upgrading to Electron 3.1.

We still have about 30 occurrences of `waitsFor` to eliminate in order for the tests to be completely free of reliance Jasmine async helpers.