### PR TITLE
different confirmCompletion default value

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       "title": "Keymap For Confirming A Suggestion",
       "description": "You should use the key(s) indicated here to confirm a suggestion from the suggestion list and have it inserted into the file.",
       "type": "string",
-      "default": "tab and enter",
+      "default": "tab always, enter when suggestion explicitly selected",
       "enum": [
         "tab",
         "enter",


### PR DESCRIPTION
### Description of the Change
This changes the default value of the `confirmCompletion` config key to `tab always, enter when explicitly selected`.

### Alternate Designs
None.

### Benefits
The current behavior is confusing with the default completions, because basically everything you type will cause the dropdown menu to appear; it's then impossible to insert a new line unless you press Escape first.

### Possible Drawbacks
Some people might not like it, but that's the case for all options, so ¯\\\_(ツ)\_/¯.
