### PR TITLE
Update deprecated `require('shell')` to `require('electron').shell` (for Atom's Electron upgrade PR)

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -227,7 +227,7 @@ class AutocompleteManager {
         let descriptionContainer = suggestionListView.querySelector('.suggestion-description')
         if (descriptionContainer !== null && descriptionContainer.style.display === 'block') {
           let descriptionMoreLink = descriptionContainer.querySelector('.suggestion-description-more-link')
-          require('shell').openExternal(descriptionMoreLink.href)
+          require('electron').shell.openExternal(descriptionMoreLink.href)
         }
       }
     }))

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -1990,7 +1990,7 @@ defm`
     describe('Keybind to navigate to descriptionMoreLink', () => {
       it('triggers openExternal on keybind if there is a description', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', description: 'it is ab'}])
-        let shell = require('shell')
+        let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 
         triggerAutocompletion(editor, true, 'a')
@@ -2003,7 +2003,7 @@ defm`
 
       it('does not trigger openExternal on keybind if there is not a description', async () => {
         spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}])
-        let shell = require('shell')
+        let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 
         triggerAutocompletion(editor, true, 'a')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Change deprecated `require('shell')` to `require('electron').shell`.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

None

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Fixes a CI failure for Atom's CI with newer Electron. For example: [CI run](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=930&view=logs&j=c5d9a21a-e43e-5eaa-4a5a-044feacfb7bd&t=1bdeab21-3bba-5fef-2971-1d9f5fd6fff7&l=295)

<details><summary>Error message (click to expand)</summary>

```
Autocomplete Manager
  when an external provider is registered
    Keybind to navigate to descriptionMoreLink
      it Autocomplete Manager when an external provider is registered Keybind to navigate to descriptionMoreLink triggers openExternal on keybind if there is a description
        Error: Deprecated function(s) Object.<anonymous>) were called.
          Object.<anonymous> is deprecated. Use `require("electron").shell` instead of `require("shell")`
          -----------------------------------------------------------------------------------------------
          Object.<anonymous> -- /Users/runner/work/1/s/exports/shell.js:4:6
          Object.<anonymous> -- /Users/runner/work/1/s/exports/shell.js:9:3
          Module._compile -- /Users/runner/work/1/s/src/native-compile-cache.js:121:30
          Object..js -- /Users/runner/work/1/s/src/compile-cache.js:255:23
          Module.load -- /Users/runner/work/1/s/node_modules/coffee-script/lib/coffee-script/register.js:45:36
          Function._load -- internal/modules/cjs/loader.js:560:12
      it Autocomplete Manager when an external provider is registered Keybind to navigate to descriptionMoreLink does not trigger openExternal on keybind if there is not a description
        Error: Deprecated function(s) Object.<anonymous>) were called.
          Object.<anonymous> is deprecated. Use `require("electron").shell` instead of `require("shell")`
          -----------------------------------------------------------------------------------------------
          Object.<anonymous> -- /Users/runner/work/1/s/exports/shell.js:4:6
          Object.<anonymous> -- /Users/runner/work/1/s/exports/shell.js:9:3
          Module._compile -- /Users/runner/work/1/s/src/native-compile-cache.js:121:30
          Object..js -- /Users/runner/work/1/s/src/compile-cache.js:255:23
          Module.load -- /Users/runner/work/1/s/node_modules/coffee-script/lib/coffee-script/register.js:45:36
          Function._load -- internal/modules/cjs/loader.js:560:12
```

</details>

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Follow-up to: https://github.com/atom/atom/pull/21805 (https://github.com/atom/atom/pull/21805/commits/1190928fbb89cad05150e9547b20f514dd534d1e)

Useful for completing the Electron 9 upgrade: https://github.com/atom/atom/pull/21777

<!-- Enter any applicable Issues here -->
