### PR TITLE
Implement the Provider API 4.1.0 with the new RFC

### DIFF
--- a/lib/autocomplete-manager.js
+++ b/lib/autocomplete-manager.js
@@ -338,6 +338,12 @@ class AutocompleteManager {
 
         if (provider.filterSuggestions) {
           providerSuggestions = this.filterSuggestions(providerSuggestions, options)
+          if (apiVersion <= 4) {
+            providerSuggestions = this.sortSuggestions(providerSuggestions, options)
+          }
+        }
+        if (provider.sortSuggestions) {
+          providerSuggestions = this.sortSuggestions(providerSuggestions, options)
         }
         return providerSuggestions
       }))
@@ -363,7 +369,7 @@ class AutocompleteManager {
     )
   }
 
-  filterSuggestions (suggestions, {prefix}) {
+  filterSuggestions (suggestions, {prefix, editor}) {
     const results = []
     const fuzzaldrinProvider = this.useAlternateScoring ? fuzzaldrinPlus : fuzzaldrin
     for (let i = 0; i < suggestions.length; i++) {
@@ -371,20 +377,50 @@ class AutocompleteManager {
       // chosen such that suggestions with a very high match score can break out.
       let score
       const suggestion = suggestions[i]
-      suggestion.sortScore = Math.max((-i / 10) + 3, 0) + 1
-      suggestion.score = null
 
-      const text = (suggestion.snippet || suggestion.text)
-      const suggestionPrefix = suggestion.replacementPrefix != null ? suggestion.replacementPrefix : prefix
+      let text = (suggestion.filterText || suggestion.snippet || suggestion.text)
+      if (typeof text === 'object') {
+        text = text.newText
+      }
+      let suggestionPrefix
+      if (typeof (suggestion.snippet || suggestion.text) === 'object') {
+        suggestionPrefix = editor.getTextInBufferRange((suggestion.snippet || suggestion.text).range)
+      } else {
+        suggestionPrefix = suggestion.replacementPrefix != null ? suggestion.replacementPrefix : prefix
+      }
       const prefixIsEmpty = !suggestionPrefix || suggestionPrefix === ' '
       const firstCharIsMatch = !prefixIsEmpty && suggestionPrefix[0].toLowerCase() === text[0].toLowerCase()
 
       if (prefixIsEmpty) {
         results.push(suggestion)
       }
-      if (firstCharIsMatch && (score = fuzzaldrinProvider.score(text, suggestionPrefix)) > 0) {
-        suggestion.score = score * suggestion.sortScore
+      if (firstCharIsMatch && fuzzaldrinProvider.score(text, suggestionPrefix) > 0) {
         results.push(suggestion)
+      }
+    }
+    return results
+  }
+
+  sortSuggestions (suggestions, {prefix}) {
+    const fuzzaldrinProvider = this.useAlternateScoring ? fuzzaldrinPlus : fuzzaldrin
+    for (let i = 0; i < suggestions.length; i++) {
+      let score
+      const suggestion = suggestions[i]
+      suggestion.sortScore = Math.max((-i / 10) + 3, 0) + 1
+      suggestion.score = null
+
+      let text = (suggestion.sortText || suggestion.snippet || suggestion.text)
+      if (typeof text === 'object') {
+        text = text.newText
+      }
+      let suggestionPrefix
+      if (typeof (suggestion.snippet || suggestion.text) === 'object') {
+        suggestionPrefix = editor.getTextInBufferRange((suggestion.snippet || suggestion.text).range)
+      } else {
+        suggestionPrefix = suggestion.replacementPrefix != null ? suggestion.replacementPrefix : prefix
+      }
+      if (score = fuzzaldrinProvider.score(text, suggestionPrefix) > 0) {
+        suggestion.score = score * suggestion.sortScore
       }
     }
 
@@ -619,22 +655,43 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return this.editor.transact(() => {
       for (let i = 0; i < cursors.length; i++) {
         const cursor = cursors[i]
-        const endPosition = cursor.getBufferPosition()
-        const beginningPosition = [endPosition.row, endPosition.column - suggestion.replacementPrefix.length]
+        let replacementRange, newText
+        if (typeof suggestion.text === 'object' || typeof suggestion.snippet === 'object') {
+          replacementRange = (suggestion.text || suggestion.snippet).range
+          newText = (suggestion.text || suggestion.snippet).newText
+        } else {
+          const beginningPosition = cursor.getBufferPosition().translate([0, -suggestion.replacementPrefix.length])
+          const suffix = this.consumeSuffix ? this.getSuffix(this.editor, cursor.getBufferPosition(), suggestion) : ''
+          replacementRange = new Range(
+            beginningPosition,
+            cursor.getBufferPosition().translate([0, suffix.length])
+          )
+          newText = (suggestion.text || suggestion.snippet)
+        }
 
-        if (this.editor.getTextInBufferRange([beginningPosition, endPosition]) === suggestion.replacementPrefix) {
-          const suffix = this.consumeSuffix ? this.getSuffix(this.editor, endPosition, suggestion) : ''
-          if (suffix.length) { cursor.moveRight(suffix.length) }
-          cursor.selection.selectLeft(suggestion.replacementPrefix.length + suffix.length)
-
-          if ((suggestion.snippet != null) && (this.snippetsManager != null)) {
-            this.snippetsManager.insertSnippet(suggestion.snippet, this.editor, cursor)
-          } else {
-            cursor.selection.insertText(suggestion.text != null ? suggestion.text : suggestion.snippet, {
-              autoIndentNewline: this.editor.shouldAutoIndent(),
-              autoDecreaseIndent: this.editor.shouldAutoIndent()
+        if (suggestion.additionalTextEdits) {
+          for (const textEdit of suggestion.additionalTextEdits) {
+            cursor.setBufferPosition(textEdit.range.start)
+            cursor.selection.selectToBufferPosition(textEdit.range.end)
+            cursor.selection.insertText(newText, {
+              autoIndent: false,
+              autoIndentNewline: false,
+              autoDecreaseIndent: false,
             })
           }
+        }
+
+        cursor.setBufferPosition(replacementRange.end)
+        cursor.selection.selectToBufferPosition(replacementRange.start)
+
+        if ((suggestion.snippet != null) && (this.snippetsManager != null)) {
+          this.snippetsManager.insertSnippet(newText, this.editor, cursor)
+        } else {
+          cursor.selection.insertText(newText, {
+            autoIndent: false,
+            autoIndentNewline: false,
+            autoDecreaseIndent: false,
+          })
         }
       }
     }
@@ -718,7 +775,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     // bufferChanged handler decides to show suggestions, it will cancel the
     // hideSuggestionList request. If there is no bufferChanged event,
     // suggestionList will be hidden.
-    if (!textChanged) this.requestHideSuggestionList()
+    if (!textChanged) setTimeout(() => this.requestHideSuggestionList(), 100);
   }
 
   // Private: Gets called when the user saves the document. Cancels the
@@ -735,6 +792,26 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
       return newRange.containsPoint(lastCursorPosition)
     })
     if (!changeOccurredNearLastCursor) return
+
+    if (this.shouldDisplaySuggestions) {
+      // The suggestion list is already shown, check if the newly typed character
+      // is a commit character for the currently selected suggestion.
+      for (const change of changes) {
+        if (!change.newRange.containsPoint(lastCursorPosition)) {
+          return false
+        }
+
+        const selectedSuggestion = this.suggestionList.suggestionListElement.getSelectedItem()
+        const commitCharacters = selectedSuggestion && selectedSuggestion.commitCharacters || []
+        for (const char of commitCharacters) {
+          if (change.newText.startsWith(char)) {
+            this.addCommitCharacter(selectedSuggestion, char)
+            this.confirm(selectedSuggestion)
+            return
+          }
+        }
+      }
+    }
 
     let shouldActivate = false
     if (this.autoActivationEnabled || this.suggestionList.isActive() && !this.compositionInProgress) {
@@ -764,6 +841,30 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     } else {
       this.cancelNewSuggestionsRequest()
       this.hideSuggestionList()
+    }
+  }
+
+  addCommitCharacter (suggestion, character) {
+    if (suggestion.snippet != null) {
+      if (typeof suggestion.snippet === 'object') {
+        suggestion.snippet.newText += character
+        suggestion.snippet.range = new Range(
+          suggestion.snippet.range.start,
+          suggestion.snippet.range.end.translate([0, character.length]),
+        )
+      } else {
+        suggestion.snippet += character
+      }
+    } else {
+      if (typeof suggestion.text === 'object') {
+        suggestion.text.newText += character
+        suggestion.text.range = new Range(
+          suggestion.text.range.start,
+          suggestion.text.range.end.translate([0, character.length]),
+        )
+      } else {
+        suggestion.text += character
+      }
     }
   }
 

--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -145,6 +145,10 @@ module.exports = class SuggestionListElement {
         })
       )
       this.setDescriptionMoreLink(item)
+    } else if (item.descriptionHTML && item.descriptionHTML.length > 0) {
+      this.descriptionContainer.style.display = 'block'
+      this.descriptionContent.innerHTML = createDOMPurify().sanitize(item.descriptionHTML)
+      this.setDescriptionMoreLink(item)
     } else if (item.description && item.description.length > 0) {
       this.descriptionContainer.style.display = 'block'
       this.descriptionContent.textContent = item.description


### PR DESCRIPTION
### Description of the Change

Implement the additional features for the Provider API in order to support LSP
Relevant issue describing the new API in detail: https://github.com/atom/autocomplete-plus/issues/1101

### Benefits

LSP compliance will allow much smarter autocompletion for supporting languages

### Possible Drawbacks

There are a couple of points where the behaviour was slightly altered:

* Atom's auto-indentation system has misbehaved so now we pass parameters to `insertText` that disable any whitespace modification by the package itself to comply with the LSP spec and allow providers to handle indentation

I tried various parameters in [`Selection.insertText`](https://flight-manual.atom.io/api/v1.53.0/Selection/#instance-insertText) but none of them worked properly. Originally I had an idea to create another setting where providers could ask the package not to do any whitespace modification, which would have been perfect and backwards-compatible, but it seems like the whitespace modification didn't work in the first place, so technically we are still backwards-compatible, albeit due to broken Atom behaviour.
OR maybe I messed up while experimenting, that's also a possibility. I'm willing to elaborate on my findings if needed.

* Hiding the Autocomplete window on cursor movement without text modification now happens 100ms after the cursor movement

This is a hack to support commit characters in light of Bracket Matcher's behaviour. Here's the situation in more detail:
A _commit character_ is a character that you can type while you have your Autocomplete suggestions dropdown visible and a preferred item selected. When you type that character, it causes the selected item to be confirmed and inserted, and the commit character to be inserted after it.
For example, it could be used in completing functions, where the commit character is `(`. Typing an opening parenthesis allows you to confirm the suggestion and keep coding right away.

The problem is the Bracket Matcher. When you type an opening parenthesis, the Bracket Matcher also types the closing parenthesis and then moves the cursor left to allow you to keep writing without disturbance. This cursor movement, however, is caught by the cursor observer and it causes the autocomplete suggestion list to be hidden before the "text edited" callback gets a chance to run and a commit character gets to be detected. This slight hack will give the "text edited" callback some time.

I agree this is not a pretty solution, but my aim was to make as few changes to the codebase as possible, and that's what I came up with. I'm open to changing this behaviour.

* The `replacementPrefix` is no longer checked before replacing the suggestion.

Now that the new `TextEdit` objects can span arbitrary ranges, checking for replacement prefix matching is no longer an option, and frankly I'm not sure if that's even needed.

### Applicable Issues

Closes https://github.com/atom/autocomplete-plus/issues/1101

### P.S.

I must confess I'm not entirely proud of the code I have written. My goal was to remain as backwards-compatible as possible and change as little code as possible. However, the codebase is in dire need of cleanup, the deprecated APIs should be removed, blah blah. But again, I need your permission to do it. I'm gladly willing to convert the codebase to TypeScript, refactor and properly deprecate stuff if you say this is acceptable.

Tests are failing, by the way, will fix them in upcoming commits, but figured I'd publish the changes to spark discussion. 
