### PR TITLE
Upgrade to Jasmine 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -75,6 +75,66 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
+    },
+    "atom-jasmine3-test-runner": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/atom-jasmine3-test-runner/-/atom-jasmine3-test-runner-5.1.8.tgz",
+      "integrity": "sha512-TOc/JgA0EmyQ6lc1RjK1Tsv1/tNvUJiH0GqK/zbKUTRER38rhsEv6WGMsF6pq9AOgX4KVjrUeuAgMFlz+FbLBQ==",
+      "dev": true,
+      "requires": {
+        "etch": "^0.14.1",
+        "find-parent-dir": "^0.3.0",
+        "fs-plus": "3.1.1",
+        "glob": "^7.1.6",
+        "grim": "^2.0.3",
+        "jasmine": "~3.6.3",
+        "jasmine-local-storage": "^1.1.1",
+        "jasmine-pass": "^1.1.0",
+        "jasmine-should-fail": "^1.1.7",
+        "jasmine-unspy": "^1.1.0",
+        "jasmine2-atom-matchers": "^1.1.7",
+        "jasmine2-focused": "^1.1.1",
+        "jasmine2-json": "^1.1.1",
+        "jasmine2-tagged": "^1.1.1",
+        "semver": "^7.3.2",
+        "temp": "^0.9.4",
+        "underscore-plus": "^1.7.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "grim": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.3.tgz",
+          "integrity": "sha512-FM20Ump11qYLK9k9DbL8yzVpy+YBieya1JG15OeH8s+KbHq8kL4SdwRtURwIUHniSxb24EoBUpwKfFjGNVi4/Q==",
+          "dev": true,
+          "requires": {
+            "event-kit": "^2.0.0"
+          }
+        },
+        "temp": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+          "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^0.5.1",
+            "rimraf": "~2.6.2"
+          }
+        }
+      }
     },
     "atom-slick": {
       "version": "2.0.0",
@@ -271,9 +331,9 @@
       }
     },
     "dompurify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
-      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
     },
     "es5-ext": {
       "version": "0.10.50",
@@ -477,6 +537,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/etch/-/etch-0.14.1.tgz",
+      "integrity": "sha512-+IwqSDBhaQFMUHJu4L/ir0dhDoW5IIihg4Z9lzsIxxne8V0PlSg0gnk2STaKWjGJQnDR4cxpA+a/dORX9kycTA==",
+      "dev": true
+    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -523,6 +589,12 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-root": {
       "version": "1.1.0",
@@ -748,6 +820,96 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "jasmine": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.3.tgz",
+      "integrity": "sha512-Th91zHsbsALWjDUIiU5d/W5zaYQsZFMPTdeNmi8GivZPmAaUAK8MblSG3yQI4VMGC/abF2us7ex60NH1AAIMTA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.6",
+        "jasmine-core": "~3.6.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "jasmine-core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
+      "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
+      "dev": true
+    },
+    "jasmine-local-storage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jasmine-local-storage/-/jasmine-local-storage-1.1.1.tgz",
+      "integrity": "sha512-GBqtas3l8SBo39NwjbHuzWhQhgHabq/mVVDabGvKLUXRFH8GtPy4jPKRIMDLWC+q7S+q4M6pIY4OHoVuU8hsCQ==",
+      "dev": true
+    },
+    "jasmine-pass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-pass/-/jasmine-pass-1.1.0.tgz",
+      "integrity": "sha512-gtsHtIj1zNS/90REIpyDH2HRSW7vFwKMau5A2hcfL/RsSwUiKAS8EdOY1Z67m8giyaUMe7I8O7SzJF2oevCX0A==",
+      "dev": true
+    },
+    "jasmine-should-fail": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/jasmine-should-fail/-/jasmine-should-fail-1.1.7.tgz",
+      "integrity": "sha512-MNtae0/NUAU0OknPcM4cTA04JEXmxMH0+hqZxBjdt4+8LvDqm+oYIQcY70OqpRwVhTTcAyG7HxiPw/4AGlxfgw==",
+      "dev": true
+    },
+    "jasmine-unspy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jasmine-unspy/-/jasmine-unspy-1.1.1.tgz",
+      "integrity": "sha512-hTuMR1ju73BkGG8OCY6ObtimVBqnyThwUuclXW81lOiT/pyBt2W5nZtNAd8N7jzUfjQDd7+m+0DPm5Ecf6T2Pw==",
+      "dev": true
+    },
+    "jasmine2-atom-matchers": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/jasmine2-atom-matchers/-/jasmine2-atom-matchers-1.1.7.tgz",
+      "integrity": "sha512-9xJALLB9suLGxSkN063Wf0aJGTwrTgmbjgX+dr4gqBKqh5CWkdyB4pyET8rJkX2UYAQJuw0tKCgbwccNJ0CuHA==",
+      "dev": true,
+      "requires": {
+        "jquery": "^3.5.1",
+        "underscore-plus": "^1.7.0"
+      }
+    },
+    "jasmine2-focused": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jasmine2-focused/-/jasmine2-focused-1.1.1.tgz",
+      "integrity": "sha512-2NnQD+Lwqu/0RIVentOiDtdsjhP/4jJooG88rQC3A6lKHxnm2d9Q/wGbQBDZlIA7bDUrQpuHZ6d2A/lACLwfhQ==",
+      "dev": true
+    },
+    "jasmine2-json": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jasmine2-json/-/jasmine2-json-1.1.1.tgz",
+      "integrity": "sha512-D8dFHVDsDZpqgYK4eR3SYkMXypRjK0MpnHzVkO38ByXe7R3QaZDsoRt3Kh4rqI1U4iq9hkxHuKr+gy+OzuL+8g==",
+      "dev": true
+    },
+    "jasmine2-tagged": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jasmine2-tagged/-/jasmine2-tagged-1.1.1.tgz",
+      "integrity": "sha512-PK/83f9hBI6R/gGZ8zEYHt4OUtZu3xpcoUFICMBVsdbbanrhCCNC3EkWldIQgvuSHaUMhVptXAihWjNJI3uiRw==",
+      "dev": true
+    },
+    "jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -807,6 +969,15 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "marked": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
@@ -827,18 +998,18 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -1113,6 +1284,15 @@
         "atom-slick": "^2"
       }
     },
+    "semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -1171,9 +1351,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -1367,6 +1547,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-slick": "^2.0.0",
-    "dompurify": "^2.0.7",
+    "dompurify": "^2.2.6",
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.6.0",
     "grim": "^2.0.1",
@@ -21,6 +21,7 @@
     "underscore-plus": "^1.6.6"
   },
   "devDependencies": {
+    "atom-jasmine3-test-runner": "^5.1.8",
     "coffeelint": "^1.9.7",
     "fs-plus": ">=2.4.0",
     "standard": "^8.3.0",
@@ -254,5 +255,6 @@
     "ignore": [
       "**/spec/fixtures/**"
     ]
-  }
+  },
+  "atomTestRunner": "./spec/custom-runner"
 }

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -71,7 +71,7 @@ return sort(Array.apply(this, arguments));
       })
     }
 
-    spyOn(autocompleteManager, 'displaySuggestions').andCallFake((suggestions, options) => {
+    spyOn(autocompleteManager, 'displaySuggestions').and.callFake((suggestions, options) => {
       displaySuggestions(suggestions, options)
       for (const resolve of suggestionsPromises) {
         resolve()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -83,7 +83,7 @@ describe('Autocomplete Manager', () => {
 
       expect(provider.onDidInsertSuggestion).toHaveBeenCalled();
 
-      ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.mostRecentCall.args[0])
+      ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.calls.mostRecent().args[0])
       expect(editor).toBe(editor)
       expect(triggerPosition).toEqual([0, 1])
       expect(suggestion.text).toBe('ab')
@@ -151,7 +151,7 @@ describe('Autocomplete Manager', () => {
     })
 
     it('it hides the suggestion list when the user keeps typing', async () => {
-      spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+      spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -206,7 +206,7 @@ describe('Autocomplete Manager', () => {
     })
 
     it('does not display empty suggestions', async () => {
-      spyOn(provider, 'getSuggestions').andCallFake(() => {
+      spyOn(provider, 'getSuggestions').and.callFake(() => {
         let list = ['ab', '', 'abcd', null]
         return (list.map((text) => ({text})))
       })
@@ -231,14 +231,14 @@ describe('Autocomplete Manager', () => {
       })
 
       it('caches the blacklist result', async () => {
-        spyOn(path, 'basename').andCallThrough()
+        spyOn(path, 'basename').and.callThrough()
 
         editor.insertText('a')
         editor.insertText('b')
         editor.insertText('c')
 
         await waitForAutocompleteToDisappear(editor)
-        expect(path.basename.callCount).toBe(1)
+        expect(path.basename.calls.count()).toBe(1)
       })
 
       it('shows suggestions when the path is changed to not match the blacklist', async () => {
@@ -278,7 +278,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => {
+        spyOn(provider, 'getSuggestions').and.callFake(() => {
           let list = ['ab', '', 'abcd', null]
           return (list.map((text) => ({text})))
         })
@@ -294,7 +294,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the type option has a space in it', () =>
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', type: 'local function'}, {text: 'abc', type: ' another ~ function   '}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', type: 'local function'}, {text: 'abc', type: ' another ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
@@ -310,7 +310,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the className option has a space in it', () =>
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', className: 'local function'}, {text: 'abc', className: ' another  ~ function   '}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', className: 'local function'}, {text: 'abc', className: ' another  ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
@@ -325,7 +325,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when multiple cursors are defined', () => {
       it('autocompletes word when there is only a prefix', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'shift'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'shift'}])
 
         editor.getBuffer().insert([0, 0], 's:extra:s')
         editor.setSelectedBufferRanges([[[0, 1], [0, 1]], [[0, 9], [0, 9]]])
@@ -355,7 +355,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('cancels the autocomplete when text differs between cursors', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [])
 
         editor.getBuffer().insert([0, 0], 's:extra:a')
         editor.setCursorBufferPosition([0, 1])
@@ -455,7 +455,7 @@ describe('Autocomplete Manager', () => {
 
         editor.setText('var something = abc')
         editor.setCursorBufferPosition([0, 10000])
-        spyOn(provider, 'getSuggestions').andCallFake((options) => {
+        spyOn(provider, 'getSuggestions').and.callFake((options) => {
           prefix = options.prefix
           resolveSuggestionsPromise()
           return []
@@ -720,7 +720,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when a suggestion description is specified', () => {
         it('shows the maxVisibleSuggestions in the suggestion popup, but with extra height for the description', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => {
+          spyOn(provider, 'getSuggestions').and.callFake(() => {
             let list = ['ab', 'abc', 'abcd', 'abcde']
             return (list.map((text) => ({text, description: `${text} yeah ok`})))
           })
@@ -740,7 +740,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('parses markdown in the description', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
+          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
             let list = [
               {text: 'ab', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmmmmmm**'},
               {text: 'abc', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmm**'},
@@ -771,7 +771,7 @@ describe('Autocomplete Manager', () => {
 
         it('adjusts the width when the description changes', async () => {
           let listWidth = null
-          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
+          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
             let list = [
               {text: 'ab', description: 'mmmmmmmmmmmmmmmmmmmmmmmmmm'},
               {text: 'abc', description: 'mmmmmmmmmmmmmmmmmmmmmm'},
@@ -874,7 +874,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when match.snippet is used', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
           let list = ['method(${1:something})', 'method2(${1:something})', 'method3(${1:something})', 'namespace\\\\method4(${1:something})']
           return (list.map((snippet) => ({snippet, replacementPrefix: prefix})))
         })
@@ -928,7 +928,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the matched prefix is highlighted', () => {
       it('highlights the prefix of the word in the suggestion list', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'items', replacementPrefix: prefix}])
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'items', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -951,7 +951,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('highlights repeated characters in the prefix', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'apply', replacementPrefix: prefix}])
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'apply', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -975,7 +975,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the prefix does not match the word', () => {
         it('does not render any character-match spans', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'omgnope', replacementPrefix: prefix}])
+          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'omgnope', replacementPrefix: prefix}])
 
           editor.moveToBottom()
           editor.insertText('x')
@@ -996,7 +996,7 @@ describe('Autocomplete Manager', () => {
           beforeEach(() => atom.packages.activatePackage('snippets'))
 
           it('does not highlight the snippet html; ref issue 301', async () => {
-            spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ab(${1:c})c'}])
+            spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'ab(${1:c})c'}])
 
             editor.moveToBottom()
             editor.insertText('c')
@@ -1010,7 +1010,7 @@ describe('Autocomplete Manager', () => {
           })
 
           it('does not highlight the snippet html when highlight beginning of the word', async () => {
-            spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'abcde(${1:e}, ${1:f})f'}])
+            spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'abcde(${1:e}, ${1:f})f'}])
 
             editor.moveToBottom()
             editor.insertText('c')
@@ -1035,7 +1035,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when a replacementPrefix is not specified', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'something'}])
       })
 
       it('replaces with the default input prefix', async () => {
@@ -1100,7 +1100,7 @@ describe('Autocomplete Manager', () => {
       let suggestion = {text: 'something'}
 
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [suggestion])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [suggestion])
       })
 
       it('adds isPrefixModified the first time suggestion is shown', async () => {
@@ -1134,7 +1134,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('places the suggestion list at the cursor', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
@@ -1149,7 +1149,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('closes the suggestion list if the user keeps typing', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -1165,7 +1165,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('keeps the suggestion list visible if the user keeps typing', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -1195,7 +1195,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('displays the suggestion list taking into account the passed back replacementPrefix', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}])
 
         editor.insertText('xxxxxxxxxxx ab:')
         triggerAutocompletion(editor, false, ':')
@@ -1207,7 +1207,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('displays the suggestion list with a negative margin to align the prefix with the word-container', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
@@ -1307,7 +1307,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the replacementPrefix is empty', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'someMethod()', replacementPrefix: ''}])
+          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'someMethod()', replacementPrefix: ''}])
         })
 
         it('will insert the text without replacing anything', async () => {
@@ -1421,7 +1421,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when a suffix of the replacement matches the text after the cursor', () => {
         it('overwrites that existing text with the replacement', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [
+          spyOn(provider, 'getSuggestions').and.callFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
 
@@ -1437,7 +1437,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('does not overwrite any text if the "consumeSuffix" setting is disabled', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [
+          spyOn(provider, 'getSuggestions').and.callFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
 
@@ -1455,7 +1455,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('does not overwrite non-word characters', async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [
+          spyOn(provider, 'getSuggestions').and.callFake(() => [
             {text: 'oneomgtwo()', replacementPrefix: 'one'}
           ])
 
@@ -1473,7 +1473,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the cursor suffix does not match the replacement', () => {
         beforeEach(() =>
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'oneomgTwo', replacementPrefix: 'one'}]))
+          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'oneomgTwo', replacementPrefix: 'one'}]))
 
         it('replaces the suffix with the replacement', async () => {
           editor.setText('ontwothree')
@@ -1524,7 +1524,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('accepts the suggestion if there is one', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1538,7 +1538,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not accept the suggestion if the event detail is activatedManually: false', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1549,7 +1549,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not accept the suggestion if auto-confirm single suggestion is disabled', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1562,7 +1562,7 @@ describe('Autocomplete Manager', () => {
 
       it('includes the correct value for activatedManually when explicitly triggered', async () => {
         let receivedOptions
-        spyOn(provider, 'getSuggestions').andCallFake((options) => {
+        spyOn(provider, 'getSuggestions').and.callFake((options) => {
           receivedOptions = options
           return [{text: 'omgok'}, {text: 'ahgok'}]
         })
@@ -1579,7 +1579,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not auto-accept a single suggestion when filtering', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
           let list = []
           if ('a'.indexOf(prefix) === 0) { list.push('a') }
           if ('abc'.indexOf(prefix) === 0) { list.push('abc') }
@@ -1600,7 +1600,7 @@ describe('Autocomplete Manager', () => {
     describe('when the replacementPrefix doesnt match the actual prefix', () => {
       describe('when snippets are not used', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something', replacementPrefix: 'bcm'}])
+          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'something', replacementPrefix: 'bcm'}])
         })
 
         it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', async () => {
@@ -1624,7 +1624,7 @@ defm`
 
       describe('when snippets are used', () => {
         beforeEach(async () => {
-          spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ok(${1:omg})', replacementPrefix: 'bcm'}])
+          spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'ok(${1:omg})', replacementPrefix: 'bcm'}])
           await atom.packages.activatePackage('snippets')
         })
 
@@ -1650,7 +1650,7 @@ defm`
 
     describe('select-previous event', () => {
       it('selects the previous item in the list', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
         await waitForAutocomplete(editor)
@@ -1669,7 +1669,7 @@ defm`
       })
 
       it('closes the autocomplete when up arrow pressed when only one item displayed', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
 
@@ -1699,7 +1699,7 @@ defm`
       })
 
       it('does not close the autocomplete when up arrow pressed with multiple items displayed but triggered on one item', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
+        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
 
@@ -1744,7 +1744,7 @@ defm`
       })
 
       it('wraps to the first item when triggered at the end of the list', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
         await waitForAutocomplete(editor)
@@ -1771,7 +1771,7 @@ defm`
     describe('label rendering', () => {
       describe('when no labels are specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1789,7 +1789,7 @@ defm`
 
       describe('when `type` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'omg'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'omg'}])
         })
 
         it('displays an icon in the icon-container', async () => {
@@ -1803,7 +1803,7 @@ defm`
 
       describe('when the `type` specified has a default icon', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'snippet'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'snippet'}])
         })
 
         it('displays the default icon in the icon-container', async () => {
@@ -1817,7 +1817,7 @@ defm`
 
       describe('when `type` is an empty string', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: ''}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: ''}])
         })
 
         it('does not display an icon in the icon-container', async () => {
@@ -1831,7 +1831,7 @@ defm`
 
       describe('when `iconHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}])
         })
 
         it('displays an icon in the icon-container', async () => {
@@ -1845,7 +1845,7 @@ defm`
 
       describe('when `iconHTML` is false', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: false}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'something', iconHTML: false}])
         })
 
         it('does not display an icon in the icon-container', async () => {
@@ -1859,7 +1859,7 @@ defm`
 
       describe('when `iconHTML` is not a string and a `type` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: true}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'something', iconHTML: true}])
         })
 
         it('displays the default icon in the icon-container', async () => {
@@ -1873,7 +1873,7 @@ defm`
 
       describe('when `iconHTML` is not a string and no type is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: true}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', iconHTML: true}])
         })
 
         it('it does not display an icon', async () => {
@@ -1887,7 +1887,7 @@ defm`
 
       describe('when `rightLabel` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1901,7 +1901,7 @@ defm`
 
       describe('when `rightLabelHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1915,7 +1915,7 @@ defm`
 
       describe('when `leftLabel` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1929,7 +1929,7 @@ defm`
 
       describe('when `leftLabelHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1944,7 +1944,7 @@ defm`
 
     describe('when clicking in the suggestion list', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => {
+        spyOn(provider, 'getSuggestions').and.callFake(() => {
           let list = ['ab', 'abc', 'abcd', 'abcde']
           return (list.map((text) => ({text, description: `${text} yeah ok`})))
         })
@@ -1989,7 +1989,7 @@ defm`
 
     describe('Keybind to navigate to descriptionMoreLink', () => {
       it('triggers openExternal on keybind if there is a description', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', description: 'it is ab'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', description: 'it is ab'}])
         let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 
@@ -2002,7 +2002,7 @@ defm`
       })
 
       it('does not trigger openExternal on keybind if there is not a description', async () => {
-        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}])
+        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}])
         let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 
@@ -2031,8 +2031,8 @@ defm`
       })
 
       ;({ autocompleteManager } = mainModule)
-      spyOn(autocompleteManager, 'findSuggestions').andCallThrough()
-      spyOn(autocompleteManager, 'displaySuggestions').andCallThrough()
+      spyOn(autocompleteManager, 'findSuggestions').and.callThrough()
+      spyOn(autocompleteManager, 'displaySuggestions').and.callThrough()
     })
 
     describe('when strict matching is used', () => {
@@ -2047,7 +2047,7 @@ defm`
         editor.insertText('o')
 
         await conditionPromise(
-          () => autocompleteManager.findSuggestions.calls.length === 1
+          () => autocompleteManager.findSuggestions.calls.count() === 1
         )
       })
     })
@@ -2193,7 +2193,7 @@ defm`
 
       it('does not update the suggestion list while composition is in progress', async () => {
         const activeElement = editorView.querySelector('input')
-        spyOn(autocompleteManager.suggestionList, 'changeItems').andCallThrough()
+        spyOn(autocompleteManager.suggestionList, 'changeItems').and.callThrough()
 
         editor.moveToBottom()
         editor.insertText('q')
@@ -2202,26 +2202,26 @@ defm`
         await waitForAutocomplete(editor)
 
         expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
-        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
-        autocompleteManager.suggestionList.changeItems.reset()
+        expect(autocompleteManager.suggestionList.changeItems.calls.mostRecent().args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.calls.reset()
 
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {data: 'i', target: activeElement}))
         triggerAutocompletion(editor, false, 'i')
 
         await conditionPromise(() =>
-          autocompleteManager.suggestionList.changeItems.callCount > 0
+          autocompleteManager.suggestionList.changeItems.calls.count() > 0
         )
 
-        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
-        autocompleteManager.suggestionList.changeItems.reset()
+        expect(autocompleteManager.suggestionList.changeItems.calls.mostRecent().args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.calls.reset()
 
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: 'ï', target: activeElement}))
         editor.selectLeft()
 
         editor.insertText('ï')
 
-        const initialCallCount = autocompleteManager.suggestionList.changeItems.callCount
-        await conditionPromise(() => autocompleteManager.suggestionList.changeItems.callCount > initialCallCount)
+        const initialCallCount = autocompleteManager.suggestionList.changeItems.calls.count()
+        await conditionPromise(() => autocompleteManager.suggestionList.changeItems.calls.count() > initialCallCount)
 
         expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalledWith(null)
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: activeElement}))

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -1,21 +1,7 @@
 const { createRunner } = require('atom-jasmine3-test-runner')
 
 const options = {
-  specHelper: {
-    atom: true,
-    attachToDom: true,
-    ci: true,
-    customMatchers: true,
-    jasmineFocused: true,
-    jasmineJson: true,
-    jasminePass: true,
-    jasmineTagged: true,
-    mockClock: true,
-    mockLocalStorage: true,
-    profile: true,
-    set: true,
-    unspy: true
-  },
+  specHelper: true,
   silentInstallation: true
 }
 

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -1,4 +1,4 @@
-const { createRunner } = require('atom-jasmine3-test-runner');
+const { createRunner } = require('atom-jasmine3-test-runner')
 
 const options = {
   specHelper: {
@@ -17,6 +17,6 @@ const options = {
     unspy: true
   },
   silentInstallation: true
-};
+}
 
-module.exports = createRunner(options);
+module.exports = createRunner(options)

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -1,0 +1,22 @@
+const { createRunner } = require('atom-jasmine3-test-runner');
+
+const options = {
+  specHelper: {
+    atom: true,
+    attachToDom: true,
+    ci: true,
+    customMatchers: true,
+    jasmineFocused: true,
+    jasmineJson: true,
+    jasminePass: true,
+    jasmineTagged: true,
+    mockClock: true,
+    mockLocalStorage: true,
+    profile: true,
+    set: true,
+    unspy: true
+  },
+  silentInstallation: true
+};
+
+module.exports = createRunner(options);

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -201,7 +201,7 @@ describe('Provider API Legacy', () => {
       triggerAutocompletion(editor, true, 'o')
       await waitForAutocomplete(editor)
 
-      let args = testProvider.requestHandler.mostRecentCall.args[0]
+      let args = testProvider.requestHandler.calls.mostRecent().args[0]
       expect(args.editor).toBeDefined()
       expect(args.buffer).toBeDefined()
       expect(args.cursor).toBeDefined()

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -96,7 +96,7 @@ describe('Provider API', () => {
         triggerAutocompletion(editor, true, 'o')
         await waitForAutocomplete(editor)
 
-        let args = testProvider.getSuggestions.mostRecentCall.args[0]
+        let args = testProvider.getSuggestions.calls.mostRecent().args[0]
         expect(args.editor).toBeDefined()
         expect(args.bufferPosition).toBeDefined()
         expect(args.scopeDescriptor).toBeDefined()

--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -1,8 +1,8 @@
 /* eslint-env jasmine */
 
 beforeEach(() => {
-  spyOn(atom.views, 'readDocument').andCallFake(fn => fn())
-  spyOn(atom.views, 'updateDocument').andCallFake(fn => fn())
+  spyOn(atom.views, 'readDocument').and.callFake(fn => fn())
+  spyOn(atom.views, 'updateDocument').and.callFake(fn => fn())
   atom.config.set('autocomplete-plus.minimumWordLength', 1)
   atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
   atom.config.set('autocomplete-plus.useCoreMovementCommands', true)

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -296,7 +296,7 @@ describe('Suggestion List Element', () => {
     })
 
     it('cycles to the last element in the suggestion list when the current selection is at the start of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
 
       suggestionListElement.moveSelectionUp()
@@ -307,7 +307,7 @@ describe('Suggestion List Element', () => {
 
   describe('moveSelectionDown', () => {
     it('increases the selected index if the current selection is not at the end of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
       suggestionListElement.selectedIndex = 3
 
@@ -325,7 +325,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
 
       suggestionListElement.model = model
       suggestionListElement.selectedIndex = 4
@@ -338,7 +338,7 @@ describe('Suggestion List Element', () => {
     })
 
     it('cycles to the first element in the suggestion list when the current suggestion is at the end of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
       suggestionListElement.selectedIndex = 4
 
@@ -381,7 +381,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a'])
 
       suggestionListElement.model = model
       suggestionListElement.moveToCancel = true
@@ -424,7 +424,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveToBottom')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
+      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a'])
 
       suggestionListElement.model = model
       suggestionListElement.moveToCancel = true


### PR DESCRIPTION
### Description of the Change

This will replace the default Atom test runner powered by the long outdated Jasmine 1.3 with a new custom test runner powered by the latest Jasmine 3.6.

### Benefits

The documentation of Jasmine 1.3 is very poor, so upgrading the version will allow developers to write tests more efficiently with the new Jasmine docs. It also improves the developer experience because Jasmine 3 is more pleasant to work with.

### Possible Drawbacks

Not that I can think of any.