### PR TITLE
Bump marked from 0.7.0 to 4.0.10

### DIFF
--- a/lib/suggestion-list-element.js
+++ b/lib/suggestion-list-element.js
@@ -2,7 +2,7 @@ const {CompositeDisposable} = require('atom')
 const SnippetParser = require('./snippet-parser')
 const {isString} = require('./type-helpers')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
-const marked = require('marked')
+const {marked} = require('marked')
 const createDOMPurify = require('dompurify')
 
 const createSuggestionFrag = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -979,9 +979,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.6.0",
     "grim": "^2.0.1",
-    "marked": "^0.7.0",
+    "marked": "^4.0.10",
     "minimatch": "^3.0.3",
     "selector-kit": "^0.1",
     "stable": "^0.1.5",


### PR DESCRIPTION
Equivalent (or rather more simple) than the change at: https://github.com/atom/github/pull/2731

Tests pass: https://github.com/icecream17/autocomplete-plus/actions/runs/1702274127

![screenshot as passing tests for convenience](https://user-images.githubusercontent.com/58114641/149634422-c55b4df1-7526-4afd-b138-668438abdca9.png)
